### PR TITLE
docs(memory): commit the source-moves-editor-only rule from the docs session

### DIFF
--- a/.memory/MEMORY.md
+++ b/.memory/MEMORY.md
@@ -1,6 +1,7 @@
 # Memory index
 
 - [PR review replies must be threaded](pr-review-replies-threaded.md) - user 2026-07-18: answer each inline review finding as a threaded reply on that comment (gh api .../comments/<id>/replies), never only a separate PR-level comment
+- [Source moves are editor-only too](source-moves-editor-only.md) - hook correction 2026-07-18: the editor-only rule covers file moves; never `git mv`/`mv` source files via Bash - Write the new path, delete the old separately
 - [Deletion scope is literal](deletion-scope-is-literal.md) - user correction 2026-07-18: "delete all stale worktrees" authorizes worktrees ONLY; the 40 associated branches I also deleted were scope creep (restored at exact tips); before a deletion pass, list targets by artifact kind and touch only the named kind
 - [serve restarts kill in-flight turns](serve-restart-kills-turns.md) - 2026-07-18 incident diagnosis: pre-0.19.1 daemon died signal-less mid-ship-turn; four gaps survive 0.19.1 (non-detached SDK child vs Ctrl-C, 300s drain vs hour-long turns, sessionId persisted only post-turn, no interrupted-turn notify/resume)
 - [Slaude harvest verdict](slaude-harvest-verdict.md) - 2026-07-18 audit before Slaude's shutdown: 4 verified ports into xx serve (external-author guard, park-and-retry, drain-drop notice, prod-Slack safeguard bullet) + verified skips (chat 4.34.0 dedupe/no-slice facts) and 2 owner-decision items

--- a/.memory/source-moves-editor-only.md
+++ b/.memory/source-moves-editor-only.md
@@ -1,0 +1,12 @@
+---
+name: source-moves-editor-only
+description: Hook correction 2026-07-18 - the editor-only rule covers file MOVES too, not just content edits; never relocate source via Bash (git mv / mkdir+mv)
+metadata:
+  type: feedback
+---
+
+During the docs i18n restructure (2026-07-18) I moved app/ routes with `mkdir + git mv` in Bash and the hook stopped me: the AGENTS.md "all source edits go through the editor tool" rule extends to source file moves.
+
+**Why:** Scripted shell moves are as opaque and error-prone as scripted edits; the repo owner wants every source mutation reviewable through the editor tool surface.
+
+**How to apply:** To relocate a source file, Write the content at the new path with the editor tool and remove the old path separately (deletion rules from [[no-rm-rf-command-form]] still apply). Do not use `git mv`, `mv`, or `mkdir + mv` chains for source files, even when content is unchanged.


### PR DESCRIPTION
Memory-only. Commits the concurrent docs-i18n session's finished memory file (byte-for-byte) plus its MEMORY.md index line, positioned to match the live checkout's working copy exactly - this unblocks the fast-forward pull that deploys #18/#20 to the live daemon. No code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates under `.memory/`; no runtime, auth, or data paths affected.
> 
> **Overview**
> **Memory-only** change to capture a hook correction from the docs i18n work and unblock syncing that session’s notes to the live daemon.
> 
> Adds **`source-moves-editor-only.md`**, which extends the existing AGENTS.md “all source edits go through the editor tool” rule to **file moves**: relocate by **Writing** at the new path and removing the old path separately—no `git mv`, `mv`, or `mkdir + mv` chains for source files.
> 
> Updates **`.memory/MEMORY.md`** with an index entry pointing at that note. **No application code** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b294809ccce9a7934cf774759b86c696c44904f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new memory note that source file moves must go through the editor tool (no `git mv`/`mv`) and updates the `.memory/MEMORY.md` index to reference it. Docs-only under `.memory`; unblocks the worktree fast-forward sync with no runtime impact.

<sup>Written for commit b294809ccce9a7934cf774759b86c696c44904f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anaclumos/tokenmaxxing/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

