### PR TITLE
fix: close the 25 confirmed iteration-4 closing-review findings + 3 critic gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,20 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun test
+      # Artifact-class verification: bun test cannot catch a broken TARBALL
+      # (0.2.0 shipped an exec-format-error binary that every test passed
+      # around). Assert the two silent-loss surfaces - the committed exec bit
+      # on the bun-shebang bin, and the serve-plugin dot-directory that npm
+      # pack ignore rules could drop - then install the tarball globally and
+      # run it, exactly what `bun i -g tokenmaxxing` does on the Linux boxes.
+      - name: Pack and verify the artifact
+        run: |
+          npm pack
+          tar tvf tokenmaxxing-*.tgz > /tmp/tarlist.txt
+          grep -F "package/src/serve-plugin/.claude-plugin/plugin.json" /tmp/tarlist.txt
+          grep -E "^-rwx[-rwx]+ .* package/src/main.ts$" /tmp/tarlist.txt
+          bun add -g ./tokenmaxxing-*.tgz
+          tokenmaxxing help
 
   publish:
     if: github.event_name == 'release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
           tar tvf tokenmaxxing-*.tgz > /tmp/tarlist.txt
           grep -F "package/src/serve-plugin/.claude-plugin/plugin.json" /tmp/tarlist.txt
           grep -E "^-rwx[-rwx]+ .* package/src/main.ts$" /tmp/tarlist.txt
-          bun add -g ./tokenmaxxing-*.tgz
+          # absolute path on purpose: bun resolves a RELATIVE tarball path
+          # against the global install dir, not cwd (reproduced locally:
+          # "ENOENT extracting tarball" - the first CI run of this step).
+          bun add -g "$PWD"/tokenmaxxing-*.tgz
           tokenmaxxing help
 
   publish:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -28,7 +28,7 @@ It is a process manager only - spawn with inherited stdio plus saved `stty -g` t
 ## 2. What tokenmaxxing installs
 
 - A `claude` **supervisor** on your PATH ahead of the real binary (`~/.config/tokenmaxxing/bin/claude`), or a shell function - you invoke it identically.
-- Four `~/.claude/settings.json` entries (merged, preserving anything you already have): a transparent `statusLine` shim, a `subagentStatusLine` shim (per-subagent rows in the agents panel), a `Stop` hook, a `SessionStart` hook.
+- Four `~/.claude/settings.json` entries (merged - other settings keys are preserved, but the `statusLine` slot is taken over): the tokenmaxxing `statusLine` renderer (native since 2026-07-11; it also tees usage), a `subagentStatusLine` (per-subagent rows in the agents panel), a `Stop` hook, a `SessionStart` hook.
 - **`~/.config/tokenmaxxing/`** - the single home for config and state:
   - `config.json` - threshold, account order/policy.
   - `accounts.json` - non-secret index `{email, organizationUuid, accountUuid, lastUsage, resetsAt, needs_reauth}`.
@@ -37,17 +37,19 @@ It is a process manager only - spawn with inherited stdio plus saved `stty -g` t
   - `bin/claude` - the supervisor.
 - Per-account **credentials** follow the platform's Claude Code store: macOS = login-keychain items `tokenmaxxing-cred-<accountUuid[:8]>` (never plaintext on disk); Linux = 0600 files `creds/tokenmaxxing-cred-<accountUuid[:8]>.json` (the same plaintext model claude itself uses - its Linux build has no keyring path at all, binary-verified 2.1.205). One `credstore` facade dispatches on a `{kind: keychain|file}` target; call sites never branch on platform.
 
-No background daemon - it's event-driven (statusline pushes usage; hooks + supervisor react). The `claude` binary and `~/.claude` layout are untouched.
+- A periodic check job (`com.tokenmaxxing.check` launchd agent on macOS, `tokenmaxxing-check.timer` systemd user timer on Linux) running `tokenmaxxing check` every 180s: hooks alone miss long agentic turns, so the timer is the backstop that keeps switching engaged mid-turn.
+
+The switching path runs no long-lived daemon - the statusline pushes usage and hooks + supervisor react, with the periodic check job above as its only recurring process (`xx serve`, the opt-in Slack bridge, is a separate long-lived daemon). The `claude` binary and `~/.claude` layout are untouched.
 
 ---
 
 ## 3. How a switch happens
 
 ### 3.1 Usage feed (free, push-based)
-The Stop hook's stdin has no usage data, but the **statusLine does** (`rate_limits.{five_hour,seven_day}.{used_percentage,resets_at}`, after every turn, 300ms debounce, zero cost). tokenmaxxing's statusLine shim tees that to `usage.json` (write-on-change, O(ms)) and passes your real statusline through unchanged. Cold-start fallback if `usage.json` is absent: `TOKENMAXXING_PROBE=1 claude -p '/usage'`, with `[ -n "$TOKENMAXXING_PROBE" ] && exit 0` as the hook's first line to stop the nested process recursing (hooks fire in `-p` too). The probe scrubs every ambient credential override claude reads before the keychain (`CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_SECURESTORAGE_CONFIG_DIR`, etc.) so it can only meter the credential in the keychain item, and retries the transient empty-footer case (claude prints local stats with no percentages when its own usage fetch throttles).
+The Stop hook's stdin has no usage data, but the **statusLine does** (`rate_limits.{five_hour,seven_day}.{used_percentage,resets_at}`, after every turn, 300ms debounce, zero cost). tokenmaxxing's statusLine tees that to `usage.json` (write-on-change, O(ms)) and renders its own native line (it replaced the earlier pass-through delegation on 2026-07-11: install takes the statusLine slot outright, so a pre-existing custom statusline command is overwritten). Cold-start fallback if `usage.json` is absent: `TOKENMAXXING_PROBE=1 claude -p '/usage'`, with `[ -n "$TOKENMAXXING_PROBE" ] && exit 0` as the hook's first line to stop the nested process recursing (hooks fire in `-p` too). The probe scrubs every ambient credential override claude reads before the keychain (`CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_SECURESTORAGE_CONFIG_DIR`, etc.) so it can only meter the credential in the keychain item, and retries the transient empty-footer case (claude prints local stats with no percentages when its own usage fetch throttles).
 
 ### 3.2 Detect + swap + signal (Stop hook, per turn)
-1. Read `usage.json`; `exit 0` fast if every window is under its threshold (metered per `organizationUuid`).
+1. Read `usage.json`; `exit 0` fast below the engagement floor (`policy.greedySessionFloor`, default 50% of the 5h window) unless a screening bar is already crossed. Engaged-but-under-every-bar runs the GREEDY convergence: stay when the current account wins or ties, else swap onto the strictly better account. A crossed bar forces the hard path (metered per `organizationUuid`).
 2. Else take a `flock` on `~/.config/tokenmaxxing/lock`, re-check under it (parallel sessions race - first winner already swapped), pick the best parked account (not rate-limited, furthest behind its own weekly pace first: highest remaining% / time-to-weekly-reset, since unused allowance is forfeited at the fixed per-account reset; tiebreak soonest expiry then lowest 7-day usage), and **swap the credential** (§3.4).
 3. Done - the running session adopts the new credential on its own within a request or two. Only when the pool is depleted (the decision returned a `waitUntil`: pre-parked on the soonest-recovering account, or staying on the current one when it recovers first) does the hook write `respawn/<session_id>` (atomic temp+rename).
 
@@ -77,7 +79,7 @@ Each terminal ran the supervisor, so each has its own child `claude` and its own
 ---
 
 ## 5. Rotation policy
-The decision engages at `five_hour >= 50%` (policy.greedySessionFloor): from there it greedily converges on the usable account furthest behind its weekly pace, staying put whenever the current account wins or ties. The hard bars - `five_hour >= 95%` OR `seven_day >= 98%`, per org - always force a switch and also screen candidates. "Exhausted" is a **timestamped state** (`resets_at`), not a flag - an account is a candidate again after it resets. Optional projected threshold (`bar - EMA(per-turn Δ%)`) so a single large turn can't blow past 100% before the next Stop hook.
+The decision engages at `five_hour >= 50%` (policy.greedySessionFloor): from there it greedily converges on the usable account furthest behind its weekly pace, staying put whenever the current account wins or ties. The hard bars - `five_hour >= 95%` OR `seven_day >= 98%`, per org - always force a switch and also screen candidates. "Exhausted" is a **timestamped state** (`resets_at`), not a flag - an account is a candidate again after it resets. Optional projected threshold (`bar - policy.projectionMargin`, a fixed configured margin) so a single large turn is less likely to blow past 100% before the next Stop hook.
 
 **Model-aware trigger.** Claude subscriptions also enforce **per-model weekly caps** - currently only for Sonnet and Fable (there is no Opus-only quota), and Fable's tighter limit binds *before* the aggregate (e.g. 80% week-Fable at only 50% week-all-models). This cap isn't in statusLine stdin, so when the active model is in `policy.switchModels` we read it from `claude -p '/usage'` (free, 0 tokens, TTL-cached) and add `week(<activeModel>) >= threshold` to the trigger. A Fable session switches on the Fable cap; a Sonnet session rides the aggregate.
 
@@ -114,9 +116,9 @@ A local Socket Mode daemon (no public URL) that turns Slack threads into Claude 
 - **Single-turn overshoot.** If one turn jumps from under the threshold straight past the wall, that turn can end rate-limited before the Stop hook swaps; the swap then still recovers the session (its next turn adopts the fresh account). Projected threshold reduces this.
 - **Shared blast radius.** All default-profile sessions share one keychain item, so a swap moves them all (each adopts in place). The `flock` + re-check is mandatory or racing hooks burn two accounts at once.
 - **Refresh-token rotation / parked-token rot.** Step 1 re-harvest is mandatory; a parked refresh token can be invalidated by logging in elsewhere → picker must catch `invalid_grant`, mark `needs_reauth`, fall through.
-- **statusLine fragility.** The shim is the most visible surface - a bug flickers or breaks your real status line. Keep it O(ms), write-on-change.
+- **statusLine fragility.** The native statusline is the most visible surface - a bug flickers or blanks the line for every session (and install takes the slot outright, replacing any custom statusline you had). Keep it O(ms), write-on-change.
 - **Keychain blob size & ps-safety.** The live `Claude Code-credentials` item also holds per-MCP-server OAuth state, so it can exceed `security -i`'s ~4KB interactive line buffer (verified on a real machine - a 4.3KB blob truncated). tokenmaxxing therefore stores parked backups as **`claudeAiOauth`-only** (small → always the ps-safe stdin write) and, on a swap, **merges** the fresh `claudeAiOauth` into the *current* live blob so MCP tokens survive the switch - using the argv write path (secret briefly visible in `ps` on your own machine) only for that one oversized live write.
-- **settings.json is user-owned.** Install by merge; ship `tokenmaxxing doctor` to verify the supervisor + 3 entries survive a `/config` edit or update.
+- **settings.json is user-owned.** Install by merge; ship `tokenmaxxing doctor` to verify the supervisor + 4 entries survive a `/config` edit or update.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ bun add -g tokenmaxxing
 tokenmaxxing init
 ```
 
-`init` imports the account you're already on, installs the `claude` supervisor + three `settings.json` entries (the tokenmaxxing statusLine, a Stop hook, a SessionStart hook), and adds the supervisor's bin dir to PATH in your shell rc (idempotent; it must sit ahead of the real `claude` to intercept it). Restart your shell, then add more accounts and go:
+`init` imports the account you're already on, installs the `claude` supervisor + four `settings.json` entries (the tokenmaxxing statusLine, a subagentStatusLine, a Stop hook, a SessionStart hook), and adds the supervisor's bin dir to PATH in your shell rc (idempotent; it must sit ahead of the real `claude` to intercept it). Restart your shell, then add more accounts and go:
 
 ```sh
 tokenmaxxing add        # logs one in, in isolation, and pools it
@@ -77,7 +77,7 @@ The **target** is chosen greedily off each account's cached windows: among usabl
 }
 ```
 
-`projectionMargin` subtracts an EMA of per-turn Δ% for pre-emption; `greedySessionFloor` is the session-used % at which the greedy convergence engages; `switchModels` names the models whose per-model cap triggers a switch; `usagePollTtlMs` is how long a `/usage` per-model poll stays fresh.
+`projectionMargin` is a fixed safety margin subtracted from each threshold bar (effective bar = threshold - margin), so a large turn is less likely to blow past a bar between checks; `greedySessionFloor` is the session-used % at which the greedy convergence engages; `switchModels` names the models whose per-model cap triggers a switch; `usagePollTtlMs` is how long a `/usage` per-model poll stays fresh.
 
 State lives entirely in `~/.config/tokenmaxxing/`. Per-account credentials follow the platform's Claude Code store: the login keychain on macOS (`tokenmaxxing-cred-<uuid8>` items, never plaintext on disk), 0600 files under `~/.config/tokenmaxxing/creds/` on Linux (the same plaintext model claude itself uses for `~/.claude/.credentials.json`).
 

--- a/src/cli/codexinit.ts
+++ b/src/cli/codexinit.ts
@@ -10,7 +10,7 @@ import { resolveRealCodex, verifyRealCodex } from "../lib/codexbin.ts";
 import { codexIdentityOf, readLiveCodexAuth, writeParkedCodexAuth } from "../lib/codexauth.ts";
 import { CodexUsageReadError, fetchCodexUsage } from "../lib/codexusage.ts";
 import { loadCodexAccounts, saveCodexAccounts } from "../lib/codexstate.ts";
-import { pinBinOverride } from "../lib/state.ts";
+import { loadConfig, pinBinOverride } from "../lib/state.ts";
 import { installCodexSupervisor, codexSupervisorLink, ensurePathInRc, shellRcPath } from "../lib/install.ts";
 import { withLock } from "../lib/lock.ts";
 import { codexCredItemFor, codexPaths } from "../lib/paths.ts";
@@ -45,6 +45,8 @@ function storePinnedAwayFromFile(): boolean {
 }
 
 export async function cmdCodexInit(): Promise<number> {
+  // Fail fast on a broken merged config before installing (see cmdInit).
+  loadConfig();
   const real = resolveRealCodex();
   const fail = verifyRealCodex({ bin: real });
   if (fail !== null) {

--- a/src/cli/codexinit.ts
+++ b/src/cli/codexinit.ts
@@ -10,7 +10,7 @@ import { resolveRealCodex, verifyRealCodex } from "../lib/codexbin.ts";
 import { codexIdentityOf, readLiveCodexAuth, writeParkedCodexAuth } from "../lib/codexauth.ts";
 import { CodexUsageReadError, fetchCodexUsage } from "../lib/codexusage.ts";
 import { loadCodexAccounts, saveCodexAccounts } from "../lib/codexstate.ts";
-import { loadConfig, saveConfig } from "../lib/state.ts";
+import { pinBinOverride } from "../lib/state.ts";
 import { installCodexSupervisor, codexSupervisorLink, ensurePathInRc, shellRcPath } from "../lib/install.ts";
 import { withLock } from "../lib/lock.ts";
 import { codexCredItemFor, codexPaths } from "../lib/paths.ts";
@@ -51,9 +51,8 @@ export async function cmdCodexInit(): Promise<number> {
     console.error(c.red(`codex binary failed verification: ${real}: ${fail}`));
     return 1;
   }
-  const cfg = loadConfig();
-  cfg.codexBin = real;
-  saveConfig(cfg);
+  // Sparse write: only the pin lands in the file, never the merged config.
+  pinBinOverride({ key: "codexBin", bin: real });
 
   if (storePinnedAwayFromFile()) {
     console.error(c.red("codex config.toml pins cli_auth_credentials_store away from the plain auth.json file tokenmaxxing swaps."));

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -10,7 +10,7 @@ import { isPlainObject } from "es-toolkit";
 import { get, set, unset } from "es-toolkit/compat";
 import { z } from "zod";
 import { paths, realClaudeBinFromEnv, realCodexBinFromEnv } from "../lib/paths.ts";
-import { ConfigFileSchema, loadConfig } from "../lib/state.ts";
+import { ConfigFileSchema, loadConfig, mergeConfigFile } from "../lib/state.ts";
 import { writeFileAtomic } from "../lib/atomic.ts";
 import { c } from "./render.ts";
 
@@ -113,6 +113,15 @@ function cmdSet(key: string, valueText: string): number {
   const validated = ConfigFileSchema.safeParse(next);
   if (!validated.success) {
     console.error(c.red(`rejected: ${validated.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join("; ")}`));
+    return 1;
+  }
+  // The per-field gate passed; the MERGED whole must too, or this write makes
+  // every later loadConfig throw (the projectionMargin-vs-thresholds refine),
+  // silently disabling status/switch/hooks/statusline until the file is
+  // hand-repaired (closing-review catch).
+  const mergedCheck = mergeConfigFile(validated.data);
+  if (!mergedCheck.ok) {
+    console.error(c.red(`rejected: ${mergedCheck.detail}`));
     return 1;
   }
   writeRawFile({ raw: next });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -6,7 +6,8 @@ import { isApiKeyMode, readOAuthAccount } from "../lib/claudejson.ts";
 import { readItem, writeItem, liveTarget, parkedTarget, mergeIntoLive } from "../lib/credstore.ts";
 import { refreshCredential, isAccessTokenExpiring, fetchTokenOrg } from "../lib/oauth.ts";
 import { withClaudeRefreshLock } from "../lib/claudelock.ts";
-import { loadAccounts, saveAccounts, loadConfig, saveConfig } from "../lib/state.ts";
+import { loadAccounts, saveAccounts, pinBinOverride } from "../lib/state.ts";
+import { withLock } from "../lib/lock.ts";
 import { installSupervisor, shellRcPath, ensurePathInRc, timerActivationHint, type InstallOutcome } from "../lib/install.ts";
 import { resolveVerifiedClaude } from "../lib/claudebin.ts";
 import { credItemFor, paths } from "../lib/paths.ts";
@@ -57,10 +58,9 @@ export async function cmdInit(): Promise<number> {
     // repair the claudeBin pin too - hooks run with claude's PATH and must
     // never have to guess which binary is the real claude. Verified pinning:
     // a pin that fails --version (or loops back into the wrapper) is replaced
-    // by a fresh PATH scan instead of being re-saved.
-    const cfg = loadConfig();
-    cfg.claudeBin = resolveVerifiedClaude();
-    saveConfig(cfg);
+    // by a fresh PATH scan instead of being re-saved. Sparse write: only the
+    // pin lands in the file, never the merged config.
+    pinBinOverride({ key: "claudeBin", bin: resolveVerifiedClaude() });
     const active = existingIdx.accounts.find((a) => a.accountUuid === existingIdx.activeAccountUuid);
     console.log(`${c.green("✓")} re-installed supervisor + hooks (pool already has ${existingIdx.accounts.length} account${existingIdx.accounts.length === 1 ? "" : "s"} - not re-importing)`);
     reportTimer(out);
@@ -117,30 +117,35 @@ export async function cmdInit(): Promise<number> {
 
   const uuid = oauthAccount.accountUuid;
   const keychainItem = credItemFor(uuid);
-  await writeItem(parkedTarget(keychainItem), JSON.stringify({ claudeAiOauth: creds })); // park a small backup
+  // Park + index update under the tokenmaxxing flock, like every sibling
+  // index writer (add/auth/rm/status/rename): unlocked, a concurrent `xx add`
+  // completing between this path's load and save had its just-registered
+  // account silently clobbered out of the index (closing-review catch).
+  const account = await withLock(paths.lockFile, async () => {
+    await writeItem(parkedTarget(keychainItem), JSON.stringify({ claudeAiOauth: creds })); // park a small backup
+    const idx = loadAccounts();
+    const existing = idx.accounts.find((a) => a.accountUuid === uuid);
+    const imported: Account = {
+      accountUuid: uuid,
+      email: oauthAccount.emailAddress,
+      organizationUuid: oauthAccount.organizationUuid,
+      label: existing?.label ?? oauthAccount.emailAddress,
+      keychainItem,
+      oauthAccount,
+      addedAt: existing?.addedAt ?? new Date().toISOString(),
+      subscriptionType: blob.claudeAiOauth.subscriptionType,
+      rateLimitTier: blob.claudeAiOauth.rateLimitTier,
+      needsReauth: false,
+    };
+    if (existing) Object.assign(existing, imported);
+    else idx.accounts.push(imported);
+    idx.activeAccountUuid = uuid;
+    saveAccounts(idx);
+    return imported;
+  });
 
-  const idx = loadAccounts();
-  const existing = idx.accounts.find((a) => a.accountUuid === uuid);
-  const account: Account = {
-    accountUuid: uuid,
-    email: oauthAccount.emailAddress,
-    organizationUuid: oauthAccount.organizationUuid,
-    label: existing?.label ?? oauthAccount.emailAddress,
-    keychainItem,
-    oauthAccount,
-    addedAt: existing?.addedAt ?? new Date().toISOString(),
-    subscriptionType: blob.claudeAiOauth.subscriptionType,
-    rateLimitTier: blob.claudeAiOauth.rateLimitTier,
-    needsReauth: false,
-  };
-  if (existing) Object.assign(existing, account);
-  else idx.accounts.push(account);
-  idx.activeAccountUuid = uuid;
-  saveAccounts(idx);
-
-  const cfg = loadConfig();
-  cfg.claudeBin = resolveVerifiedClaude();
-  saveConfig(cfg);
+  // Sparse write: only the pin lands in the file, never the merged config.
+  pinBinOverride({ key: "claudeBin", bin: resolveVerifiedClaude() });
 
   const out = installSupervisor();
 
@@ -151,8 +156,9 @@ export async function cmdInit(): Promise<number> {
     console.log();
     ensurePathAhead();
   }
+  const poolSize = loadAccounts().accounts.length;
   console.log();
-  console.log(`  pool ready (${idx.accounts.length} account${idx.accounts.length === 1 ? "" : "s"})`);
+  console.log(`  pool ready (${poolSize} account${poolSize === 1 ? "" : "s"})`);
   printUsage();
   return 0;
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -6,7 +6,7 @@ import { isApiKeyMode, readOAuthAccount } from "../lib/claudejson.ts";
 import { readItem, writeItem, liveTarget, parkedTarget, mergeIntoLive } from "../lib/credstore.ts";
 import { refreshCredential, isAccessTokenExpiring, fetchTokenOrg } from "../lib/oauth.ts";
 import { withClaudeRefreshLock } from "../lib/claudelock.ts";
-import { loadAccounts, saveAccounts, pinBinOverride } from "../lib/state.ts";
+import { loadAccounts, saveAccounts, loadConfig, pinBinOverride } from "../lib/state.ts";
 import { withLock } from "../lib/lock.ts";
 import { installSupervisor, shellRcPath, ensurePathInRc, timerActivationHint, type InstallOutcome } from "../lib/install.ts";
 import { resolveVerifiedClaude } from "../lib/claudebin.ts";
@@ -48,6 +48,13 @@ export function printUsage(): void {
 
 export async function cmdInit(): Promise<number> {
   mkdirSync(paths.home, { recursive: true });
+  // Fail fast on a broken merged config BEFORE installing or claiming a
+  // successful repair: pinBinOverride writes sparsely without validating, so
+  // without this gate a re-init printed success while hooks, switching, and
+  // the statusline kept throwing on every loadConfig until the file was
+  // hand-repaired (bugbot review catch, PR #33). The throw carries the
+  // fix-or-remove recovery message.
+  loadConfig();
 
   // Already initialized → repair install ONLY. Never re-import: ~/.claude.json's
   // oauthAccount can drift from the live keychain cred (after swaps / concurrent

--- a/src/cli/rm.ts
+++ b/src/cli/rm.ts
@@ -1,9 +1,11 @@
 // `tokenmaxxing rm <selector>` - remove a pooled account (not the active one).
 
-import { deleteItem, liveTarget, parkedTarget, readItem } from "../lib/credstore.ts";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { deleteItem, isolatedTarget, liveTarget, parkedTarget, readItem } from "../lib/credstore.ts";
 import { fetchTokenOrg } from "../lib/oauth.ts";
 import { withLock } from "../lib/lock.ts";
-import { paths } from "../lib/paths.ts";
+import { credItemFor, paths } from "../lib/paths.ts";
 import { loadAccounts, saveAccounts } from "../lib/state.ts";
 import { CredentialBlobSchema } from "../lib/types.ts";
 import { findAccount } from "./rename.ts";
@@ -49,6 +51,18 @@ export async function cmdRm(selector?: string): Promise<number> {
       }
     }
     await deleteItem(parkedTarget(a.keychainItem));
+    // Sweep sample-probe residue too: a probe killed mid-run strands the
+    // account's isolated credential (macOS: a namespaced keychain item), and
+    // once the account leaves the pool nothing would ever probe-and-heal it
+    // again (closing-review critic gap). deleteItem on a missing item is a
+    // no-op. Hard delete, not trash, on purpose: the sample dir is a
+    // throwaway CLAUDE_CONFIG_DIR that can hold PLAINTEXT credential material
+    // on Linux - the credential-dir cleanup exception (owner 2026-07-16, same
+    // rule sample.ts and onboard.ts follow); trashing would move credentials
+    // into the Trash folder.
+    const sampleDir = join(paths.sampleDir, credItemFor(a.accountUuid));
+    await deleteItem(isolatedTarget(sampleDir));
+    rmSync(sampleDir, { recursive: true, force: true });
     idx.accounts = idx.accounts.filter((x) => x.accountUuid !== a.accountUuid);
     saveAccounts(idx);
     console.log(`removed ${c.bold(a.label)} from the pool (${idx.accounts.length} left)`);

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -380,6 +380,15 @@ export function buildServeRuntime(seam: {
     isMention: boolean;
   }) => {
     const { thread, isMention } = input;
+    const link = linkForChannel(cfg, bareChannelId(thread.channelId));
+    if (!link) {
+      // checked BEFORE the draining branch: unlinked channels are
+      // contractually log-only silent, and a drain-window drop notice posted
+      // into one would tell a user to resend a message that will never be
+      // served (closing-review catch).
+      log("serve.unlinked_channel", { channel: thread.channelId });
+      return; // not a linked channel - stay silent in Slack
+    }
     if (draining) {
       // the socket stays connected until the drain finishes; anything landing
       // in that window is dropped loudly rather than spawning an unwaitable
@@ -405,11 +414,6 @@ export function buildServeRuntime(seam: {
       );
       return;
     }
-    const link = linkForChannel(cfg, bareChannelId(thread.channelId));
-    if (!link) {
-      log("serve.unlinked_channel", { channel: thread.channelId });
-      return; // not a linked channel - stay silent in Slack
-    }
     log("serve.message", { thread: thread.id, isMention, texts: input.relayed.length });
     // relayed carries queue-skipped messages plus the triggering one: the
     // queue strategy hands a turn only the LATEST message and the rest via
@@ -433,6 +437,15 @@ export function buildServeRuntime(seam: {
       saveSlackThread(record);
       log("serve.thread_opened", { thread: thread.id, cwd: link.repo });
     }
+    // Inside the serialized chain a marker can only be a PREVIOUS
+    // generation's killed turn (this generation's turns clear theirs before
+    // releasing the chain, and the serve-lock keeps generations exclusive):
+    // an inbound message can win the chain ahead of startup recovery (e.g.
+    // Slack redelivering the killed turn's unacked mention), and runTurn's
+    // fresh marker would silently discard the orphan's pid identity - reap it
+    // here so two claude processes never share the thread's cwd and session
+    // (closing-review catch, the recovery-path reap alone loses this race).
+    if (record.activeTurn) await reapOrphan(record.activeTurn);
     // subscriptions live in the memory state, so a daemon restart forgets
     // them; every mention re-subscribes to keep follow-up replies flowing.
     if (isMention) await thread.subscribe();

--- a/src/cli/switch.ts
+++ b/src/cli/switch.ts
@@ -37,6 +37,7 @@ export async function cmdSwitch(selector?: string): Promise<number> {
   return withLock(paths.lockFile, async () => {
     const idx = loadAccounts();
     const claimed = readOAuthAccount()?.accountUuid ?? null;
+    const claimedOrg = readOAuthAccount()?.organizationUuid ?? null;
     const drifted = claimed != null && claimed !== idx.activeAccountUuid;
 
     const swapTo = async (target: Account): Promise<number> => {
@@ -72,12 +73,14 @@ export async function cmdSwitch(selector?: string): Promise<number> {
     while (true) {
       const cur = loadAccounts();
       // The seat is the LIVE login's pooled account when resolvable, the
-      // stored label only as fallback - the same identity rule decide.ts's
-      // seatOf applies (bugbot review catch, PR #33). Under drift this also
-      // makes ties favor the live account: the realign swap then keeps the
-      // same credential instead of hopping accounts on a tie.
+      // stored label only as fallback - the same identity rule AND the same
+      // identity KEY as decide.ts's seatOf: the organizationUuid, since quota
+      // is metered per org and the org is what the roles endpoint verifies
+      // (bugbot review catches, PR #33). Under drift this also makes ties
+      // favor the live account: the realign swap then keeps the same
+      // credential instead of hopping accounts on a tie.
       const active =
-        (claimed != null ? cur.accounts.find((a) => a.accountUuid === claimed) : null) ??
+        (claimedOrg != null ? cur.accounts.find((a) => a.organizationUuid === claimedOrg) : null) ??
         cur.accounts.find((a) => a.accountUuid === cur.activeAccountUuid) ??
         null;
       if (active != null && currentWins(active, cur.accounts, everyone)) {

--- a/src/cli/switch.ts
+++ b/src/cli/switch.ts
@@ -18,8 +18,8 @@ import { withLock } from "../lib/lock.ts";
 import { paths } from "../lib/paths.ts";
 import { loadAccounts, loadConfig } from "../lib/state.ts";
 import { readOAuthAccount } from "../lib/claudejson.ts";
-import { performSwap, chooseAndSwap } from "../lib/swap.ts";
-import { currentWins, effectiveBars, pickEarliestReset, weeklyExpiry, type PickCtx } from "../lib/picker.ts";
+import { performSwap } from "../lib/swap.ts";
+import { currentWins, effectiveBars, pickBest, pickEarliestReset, weeklyExpiry, type PickCtx } from "../lib/picker.ts";
 import { InvalidGrantError } from "../lib/oauth.ts";
 import { findAccount } from "./rename.ts";
 import { c, fmtReset } from "./render.ts";
@@ -60,21 +60,38 @@ export async function cmdSwitch(selector?: string): Promise<number> {
 
     // auto: greedy over everyone, current included - a no-op when current wins.
     // No session context here, so every configured per-model family gates.
+    // Dead-token fallback mirrors decide.ts's greedy loop, NOT chooseAndSwap:
+    // its fallback lands on the next usable candidate unconditionally, which
+    // is right when over a bar but wrong here - a dead grant on the pace
+    // winner must re-check the seat, or a healthy current account gets a real
+    // swap onto a pace-WORSE account and the next periodic check bounces it
+    // straight back (closing-review catch). performSwap persists needs-reauth
+    // before throwing, so each reload shrinks the candidate set and the loop
+    // terminates.
     const everyone: PickCtx = { now, thresholds: effectiveBars(cfg), currentAccountUuid: null, switchFamilies: cfg.policy.switchModels };
-    const active = idx.accounts.find((a) => a.accountUuid === idx.activeAccountUuid) ?? null;
-    if (active != null && currentWins(active, idx.accounts, everyone)) {
-      if (drifted) return swapTo(active);
-      const expiry = weeklyExpiry(active, now);
-      const why = Number.isFinite(expiry) ? ` (weekly ${fmtReset(expiry, now)})` : "";
-      console.log(`already on the best account: ${c.bold(active.label)}${why}`);
-      return 0;
-    }
-    {
-      const landed = await chooseAndSwap({ now, thresholds: effectiveBars(cfg), switchFamilies: cfg.policy.switchModels });
-      if (landed) {
-        console.log(`${c.green("↻")} switched to ${c.bold(landed.label)}`);
+    while (true) {
+      const cur = loadAccounts();
+      const active = cur.accounts.find((a) => a.accountUuid === cur.activeAccountUuid) ?? null;
+      if (active != null && currentWins(active, cur.accounts, everyone)) {
+        if (drifted) return swapTo(active);
+        const expiry = weeklyExpiry(active, now);
+        const why = Number.isFinite(expiry) ? ` (weekly ${fmtReset(expiry, now)})` : "";
+        console.log(`already on the best account: ${c.bold(active.label)}${why}`);
         return 0;
       }
+      const best = pickBest(cur.accounts, { ...everyone, currentAccountUuid: cur.activeAccountUuid });
+      if (!best) break; // no usable target: the depleted path below decides
+      try {
+        await performSwap(best);
+      } catch (e) {
+        if (e instanceof InvalidGrantError) {
+          console.error(c.red(`${best.label}'s refresh token is dead - run \`tokenmaxxing auth ${best.label}\``));
+          continue;
+        }
+        throw e;
+      }
+      console.log(`${c.green("↻")} switched to ${c.bold(best.label)}`);
+      return 0;
     }
 
     // No usable target swapped in: everything is depleted, or the remaining
@@ -88,7 +105,8 @@ export async function cmdSwitch(selector?: string): Promise<number> {
       const reauth = fresh.accounts.filter((a) => a.needsReauth).map((a) => a.label);
       if (reauth.length > 0) { console.error(c.yellow(`no switchable account - reauth needed (run \`tokenmaxxing auth --all\`): ${reauth.join(", ")}`)); return 1; }
       // never freeze a label drift behind a no-op (see header).
-      if (drifted && active) return swapTo(active);
+      const freshActive = fresh.accounts.find((a) => a.accountUuid === fresh.activeAccountUuid) ?? null;
+      if (drifted && freshActive) return swapTo(freshActive);
       console.log(c.yellow("all accounts at their limit with unknown reset times (unparsed reset clocks? see tokenmaxxing.log) - staying put"));
       return 0;
     }

--- a/src/cli/switch.ts
+++ b/src/cli/switch.ts
@@ -71,7 +71,15 @@ export async function cmdSwitch(selector?: string): Promise<number> {
     const everyone: PickCtx = { now, thresholds: effectiveBars(cfg), currentAccountUuid: null, switchFamilies: cfg.policy.switchModels };
     while (true) {
       const cur = loadAccounts();
-      const active = cur.accounts.find((a) => a.accountUuid === cur.activeAccountUuid) ?? null;
+      // The seat is the LIVE login's pooled account when resolvable, the
+      // stored label only as fallback - the same identity rule decide.ts's
+      // seatOf applies (bugbot review catch, PR #33). Under drift this also
+      // makes ties favor the live account: the realign swap then keeps the
+      // same credential instead of hopping accounts on a tie.
+      const active =
+        (claimed != null ? cur.accounts.find((a) => a.accountUuid === claimed) : null) ??
+        cur.accounts.find((a) => a.accountUuid === cur.activeAccountUuid) ??
+        null;
       if (active != null && currentWins(active, cur.accounts, everyone)) {
         if (drifted) return swapTo(active);
         const expiry = weeklyExpiry(active, now);
@@ -79,7 +87,7 @@ export async function cmdSwitch(selector?: string): Promise<number> {
         console.log(`already on the best account: ${c.bold(active.label)}${why}`);
         return 0;
       }
-      const best = pickBest(cur.accounts, { ...everyone, currentAccountUuid: cur.activeAccountUuid });
+      const best = pickBest(cur.accounts, { ...everyone, currentAccountUuid: active?.accountUuid ?? null });
       if (!best) break; // no usable target: the depleted path below decides
       try {
         await performSwap(best);

--- a/src/cli/switch.ts
+++ b/src/cli/switch.ts
@@ -36,8 +36,13 @@ export async function cmdSwitch(selector?: string): Promise<number> {
 
   return withLock(paths.lockFile, async () => {
     const idx = loadAccounts();
-    const claimed = readOAuthAccount()?.accountUuid ?? null;
-    const claimedOrg = readOAuthAccount()?.organizationUuid ?? null;
+    // ONE claude.json read for both identity fields: two reads could straddle
+    // a concurrent /login and describe two different live identities - the
+    // drift check and the seat must come from the same snapshot (cubic review
+    // catch, PR #33).
+    const liveClaim = readOAuthAccount();
+    const claimed = liveClaim?.accountUuid ?? null;
+    const claimedOrg = liveClaim?.organizationUuid ?? null;
     const drifted = claimed != null && claimed !== idx.activeAccountUuid;
 
     const swapTo = async (target: Account): Promise<number> => {

--- a/src/entries/codexstophook.ts
+++ b/src/entries/codexstophook.ts
@@ -41,9 +41,20 @@ export async function handleCodexStop(input: { rawStdin: string }): Promise<void
   const sessionId = parsed.success ? (parsed.data.session_id ?? null) : null;
 
   try {
-    const decision = await evaluateAndMaybeSwapCodex({});
+    // No supervisor = no decision AT ALL, checked before evaluate can swap:
+    // hooks.json is global, so this hook also fires in sessions launched
+    // around the PATH shim (IDE extension, absolute path), and a swap with
+    // nobody to respawn strands that session - codex cannot hot-adopt, and
+    // its guarded reload refuses a cross-account auth.json, so the session
+    // dies on its stale token with "Please sign in again" (closing-review
+    // catch). Restart IS the switch; without a restarter, do not switch.
     const supervisorId = SupervisorIdSchema.parse(process.env[CODEX_SUPERVISOR_ID_ENV]);
-    if (decision.swapped && decision.account && supervisorId) {
+    if (supervisorId === undefined) {
+      log("codexstop.unsupervised_skip", {});
+      return;
+    }
+    const decision = await evaluateAndMaybeSwapCodex({});
+    if (decision.swapped && decision.account) {
       mkdirSync(codexPaths.respawnDir, { recursive: true });
       const payload = CodexRespawnMarkerSchema.parse({
         account: decision.account.label,

--- a/src/entries/supervisor.ts
+++ b/src/entries/supervisor.ts
@@ -23,6 +23,31 @@ const NONINTERACTIVE_SUBCMDS = new Set([
   "setup-token", "plugin", "agents", "completion", "help",
 ]);
 
+// Root flags whose VALUE tokens must never be read as the subcommand (e.g.
+// `--settings config` is an interactive session, not `claude config`): the
+// same hardening class shouldManageCodex got. Split by arity, mirroring
+// claude's own commander declarations (--help-verified 2.1.215; claude changes
+// monthly - a newly added value-taking flag regresses only that flag's
+// collision case). `--session-id` / `-r` / `--resume` consume their values in
+// dedicated branches below.
+const VALUE_TAKING_ROOT_FLAGS = new Set([
+  "--agent", "--agents", "--append-system-prompt", "--append-system-prompt-file",
+  "--debug-file", "--effort", "--fallback-model", "--input-format",
+  "--json-schema", "--max-budget-usd", "--model", "-n", "--name",
+  "--output-format", "--permission-mode", "--plugin-dir", "--plugin-url",
+  "--remote-control-session-name-prefix", "--setting-sources", "--settings",
+  "--system-prompt",
+]);
+// Variadic (`<x...>`): commander consumes EVERY following non-dash token.
+const VARIADIC_ROOT_FLAGS = new Set([
+  "--add-dir", "--allowedTools", "--allowed-tools", "--betas",
+  "--disallowedTools", "--disallowed-tools", "--file", "--mcp-config", "--tools",
+]);
+// Optional value (`[x]`): commander consumes the next token unless it is a flag.
+const OPTIONAL_VALUE_ROOT_FLAGS = new Set([
+  "-d", "--debug", "--from-pr", "--prompt-suggestions", "--remote-control", "-w", "--worktree",
+]);
+
 const isUuid = (s: string) => z.uuid().safeParse(s).success;
 
 const AnalysisSchema = z.object({
@@ -40,6 +65,7 @@ export function analyzeArgs(argv: string[]): Analysis {
   let printMode = false;
   let invalidSessionArg = false;
   let pickerResume = false;
+  let forkSession = false;
   let firstPositional: string | null = null;
 
   for (let i = 0; i < argv.length; i++) {
@@ -68,13 +94,27 @@ export function analyzeArgs(argv: string[]): Analysis {
       const next = argv[i + 1];
       if (next && !next.startsWith("-") && isUuid(next)) { resumeId = next; i++; }
       else pickerResume = true;
-    } else if (!a.startsWith("-") && firstPositional === null) {
+    }
+    else if (a === "--fork-session") forkSession = true;
+    else if (VALUE_TAKING_ROOT_FLAGS.has(a)) i++;
+    else if (VARIADIC_ROOT_FLAGS.has(a)) {
+      while (i + 1 < argv.length && !argv[i + 1]!.startsWith("-")) i++;
+    }
+    else if (OPTIONAL_VALUE_ROOT_FLAGS.has(a)) {
+      if (argv[i + 1] !== undefined && !argv[i + 1]!.startsWith("-")) i++;
+    }
+    else if (!a.startsWith("-") && firstPositional === null) {
       firstPositional = a;
     }
   }
 
   const isSubcmd = firstPositional !== null && NONINTERACTIVE_SUBCMDS.has(firstPositional);
-  const manage = !printMode && !isSubcmd && !invalidSessionArg && !pickerResume && !process.env.TOKENMAXXING_PROBE;
+  // A forked resume gets a NEW session id chosen inside claude, so the
+  // supervisor cannot pin marker paths - pass through unmanaged like
+  // picker-mode resume (closing-review catch: managing it paired the marker
+  // to the stale pre-fork sid, and a respawn would fork yet another session).
+  const forkResume = forkSession && (resumeId !== null || continueLatest);
+  const manage = !printMode && !isSubcmd && !invalidSessionArg && !pickerResume && !forkResume && !process.env.TOKENMAXXING_PROBE;
   return { manage, sessionId, resumeId, continueLatest };
 }
 
@@ -93,9 +133,14 @@ export function stripSessionFlags(argv: string[]): string[] {
   return out;
 }
 
-/** Newest transcript session id for the current cwd (for `-c`). */
+/** Newest transcript session id for the current cwd (for `-c`). claude's
+ *  project-dir slug maps EVERY non-alphanumeric char to "-": the regex below
+ *  mirrors claude's own, byte for byte (binary-verified 2.1.215, the external-
+ *  contract regex exception). The old [/.]-only mapping missed underscores
+ *  etc., so `-c` in such a cwd silently opened a brand-new session instead of
+ *  continuing (closing-review catch). */
 function latestSessionForCwd(): string | null {
-  const slug = process.cwd().replace(/[/.]/g, "-");
+  const slug = process.cwd().replace(/[^a-zA-Z0-9]/g, "-");
   const projDir = join(paths.claudeDir, "projects", slug);
   if (!existsSync(projDir)) return null;
   try {

--- a/src/lib/claudelock.ts
+++ b/src/lib/claudelock.ts
@@ -20,6 +20,7 @@
 import { mkdirSync, realpathSync, rmdirSync, statSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { delay } from "es-toolkit";
+import { z } from "zod";
 import { credDir } from "./paths.ts";
 import { log } from "./log.ts";
 
@@ -34,7 +35,8 @@ function tryAcquire(lockDir: string): boolean {
     mkdirSync(lockDir);
     return true;
   } catch (e) {
-    if ((e as { code?: string }).code !== "EEXIST") throw e;
+    const errno = z.object({ code: z.string() }).safeParse(e);
+    if (!errno.success || errno.data.code !== "EEXIST") throw e;
   }
   try {
     if (Date.now() - statSync(lockDir).mtimeMs > STALE_MS) {

--- a/src/lib/codexauth.ts
+++ b/src/lib/codexauth.ts
@@ -17,7 +17,12 @@ function isEnoent(e: unknown): boolean {
 
 /** auth.json at an explicit path (the live file, or an onboard dir's), or null
  *  when absent. Throws on a present-but-unparsable file: that is drift to
- *  surface, not to paper over. */
+ *  surface, not to paper over. One valid-but-unpoolable state maps to null
+ *  instead of throwing: `codex login --with-api-key` writes auth.json with
+ *  `tokens` OMITTED (serde skip_serializing_if, verified rust-v0.144.5) - the
+ *  real binary runs fine on it, so the shim and status must too, and with no
+ *  ChatGPT tokens there is nothing tokenmaxxing can pool (closing-review
+ *  catch). */
 export function readCodexAuthAt(input: { path: string }): CodexAuthJson | null {
   let raw: string;
   try {
@@ -26,7 +31,10 @@ export function readCodexAuthAt(input: { path: string }): CodexAuthJson | null {
     if (isEnoent(e)) return null;
     throw e;
   }
-  return CodexAuthJsonSchema.parse(JSON.parse(raw));
+  const parsed = JSON.parse(raw);
+  const probe = z.looseObject({ tokens: z.unknown().optional() }).parse(parsed);
+  if (probe.tokens === undefined || probe.tokens === null) return null;
+  return CodexAuthJsonSchema.parse(parsed);
 }
 
 /** The live auth.json, or null when codex has no login here. */

--- a/src/lib/codexdecide.ts
+++ b/src/lib/codexdecide.ts
@@ -17,7 +17,7 @@ import { CodexInvalidGrantError, refreshCodexAuth } from "./codexoauth.ts";
 import { fetchCodexUsage } from "./codexusage.ts";
 import { codexIdentityOf, isCodexAccessExpiring, readLiveCodexAuth, writeLiveCodexAuth, writeParkedCodexAuth } from "./codexauth.ts";
 import { liveCodexAccountId } from "./codexsample.ts";
-import { targetableCodexAccounts } from "./codexpresence.ts";
+import { presentCodexAccountIds, targetableCodexAccounts } from "./codexpresence.ts";
 import { effectiveBars } from "./picker.ts";
 import { log } from "./log.ts";
 import { CodexAccountSchema } from "./types.ts";
@@ -34,7 +34,8 @@ const POST_SWAP_COOLDOWN_MS = 45_000;
 /**
  * Sample the LIVE credential's usage and stamp it onto its TRUE owner in the
  * pool (the id_token's own identity: labels drift, the token cannot lie).
- * Refreshes the live blob first when it is near expiry, persisting the
+ * Refreshes the live blob first when it is near expiry (and no supervised
+ * session is running it - see the presence guard below), persisting the
  * rotation to the live file AND the owner's parked copy in the same step -
  * before the usage fetch, so a failed fetch can never strand the parked copy
  * on the reuse-punished superseded refresh token. A dead live grant marks the
@@ -51,7 +52,14 @@ async function sampleLiveOntoOwner(input: { now: number }): Promise<string | nul
   const owner = index.accounts.find((account) => account.accountId === identity.accountId);
   if (!owner) return null;
 
-  if (isCodexAccessExpiring({ auth: live, now })) {
+  // The near-expiry refresh is skipped while any supervised session RUNS the
+  // live account: a sibling's Stop hook (or the timer) can land mid-turn of
+  // that session, and two concurrent POSTs of the same rotating refresh token
+  // reuse-punish the loser into a dead grant family (closing-review catch).
+  // The unrotated token stays valid within the margin, so the fetch below
+  // still samples; once expired it fails loudly and the next cycle, after the
+  // running session's own refresh, recovers.
+  if (isCodexAccessExpiring({ auth: live, now }) && !presentCodexAccountIds().has(identity.accountId)) {
     try {
       live = await refreshCodexAuth({ auth: live, now });
     } catch (e) {

--- a/src/lib/codexsample.ts
+++ b/src/lib/codexsample.ts
@@ -35,16 +35,25 @@ export async function sampleCodexAccount(input: { account: CodexAccount; liveAcc
     let auth = isLive ? readLiveCodexAuth() : readParkedCodexAuth({ credFile: account.credFile });
     if (!auth) return { ok: false, reason: isLive ? "live auth.json vanished" : "no parked credential", deadGrant: false };
     if (isCodexAccessExpiring({ auth, now })) {
-      // A parked blob whose account is RUNNING in another supervised session
-      // is superseded by that session's live rotations: refreshing it would
-      // trip the server's reuse punishment and kill the running session's
-      // grant family. Skip the refresh and report a miss instead.
-      if (!isLive && presentCodexAccountIds().has(account.accountId)) {
+      // NEVER refresh a PRESENT account's token, live or parked. A parked
+      // blob whose account is RUNNING in another supervised session is
+      // superseded by that session's live rotations, and the LIVE blob's
+      // running session can be mid-turn refreshing the same rotating token
+      // concurrently (both actors share the 300s margin): either way the
+      // loser of the race is reuse-punished into a dead grant family
+      // (closing-review catch; the idle-turn-boundary safety argument covers
+      // only the invoking session's own account). Parked reports a miss; live
+      // fetches on the unrotated token, still valid within the margin, and
+      // degrades to an honest miss once it expires.
+      const running = presentCodexAccountIds().has(account.accountId);
+      if (running && !isLive) {
         return { ok: false, reason: "running in a live codex session (parked token refresh unsafe)", deadGrant: false };
       }
-      auth = await refreshCodexAuth({ auth, now });
-      if (isLive) writeLiveCodexAuth({ auth });
-      writeParkedCodexAuth({ credFile: account.credFile, auth });
+      if (!running) {
+        auth = await refreshCodexAuth({ auth, now });
+        if (isLive) writeLiveCodexAuth({ auth });
+        writeParkedCodexAuth({ credFile: account.credFile, auth });
+      }
     }
     const usage = await fetchCodexUsage({ auth });
     return { ok: true, usage };

--- a/src/lib/decide.ts
+++ b/src/lib/decide.ts
@@ -201,8 +201,13 @@ export async function evaluateAndMaybeSwap(now = Date.now(), anticipatory = fals
     const mu2 = needsPerModel(u2, cfg) ? loadModelUsage() ?? mu : null;
 
     // record the active account's aggregate usage so the picker + `status` see it.
+    // Resolved by the LIVE org the guard just verified, never the
+    // activeAccountUuid label: after a manual /login the label drifts (the
+    // surviving drift source, see cli/switch.ts), and a label-keyed write
+    // would stamp the live account's windows onto whichever account the label
+    // still names (closing-review catch, mirrors the codex live-identity rule).
     if (u2 && org2 && u2.org === org2) {
-      const active = idx.accounts.find((a) => a.accountUuid === idx.activeAccountUuid);
+      const active = idx.accounts.find((a) => a.organizationUuid === org2);
       if (active) {
         active.lastUsage = { fiveHour: u2.fiveHour, sevenDay: u2.sevenDay };
         active.lastUsageAt = u2.ts;

--- a/src/lib/decide.ts
+++ b/src/lib/decide.ts
@@ -223,6 +223,18 @@ export async function evaluateAndMaybeSwap(now = Date.now(), anticipatory = fals
       return depletedReplay(now) ?? { swapped: false, account: null, reason: "raced-already-swapped" };
     }
 
+    // The SEAT every path below evaluates and excludes: the live org's pooled
+    // account when resolvable, the stored label only as fallback - the same
+    // identity rule as the usage stamp above and depletedReplay. Trusting the
+    // label here let the greedy convergence judge a stale account as "the
+    // seat" after a manual /login, ranking against the wrong cached windows
+    // and even offering the LIVE account as a swap target (bugbot review
+    // catch, PR #33).
+    const seatOf = (idx2: { activeAccountUuid: string | null; accounts: Account[] }): Account | null =>
+      idx2.accounts.find((a) => a.organizationUuid === org2) ??
+      idx2.accounts.find((a) => a.accountUuid === idx2.activeAccountUuid) ??
+      null;
+
     // Candidates are screened by the same families that drove this decision, so
     // the pool cannot ping-pong onto an account the gate would immediately flag.
     const switchFamilies = gatedFamilies(u2?.model ?? null, cfg.policy.switchModels);
@@ -240,11 +252,11 @@ export async function evaluateAndMaybeSwap(now = Date.now(), anticipatory = fals
       const ctxAll = { now, thresholds: effectiveBars(cfg), currentAccountUuid: null, switchFamilies };
       while (true) {
         const cur = loadAccounts();
-        const active = cur.accounts.find((a) => a.accountUuid === cur.activeAccountUuid) ?? null;
+        const active = seatOf(cur);
         if (currentWins(active, cur.accounts, ctxAll)) {
           return { swapped: false, account: null, reason: "current-best" };
         }
-        const best = pickBest(cur.accounts, { ...ctxAll, currentAccountUuid: cur.activeAccountUuid });
+        const best = pickBest(cur.accounts, { ...ctxAll, currentAccountUuid: active?.accountUuid ?? null });
         if (!best) return { swapped: false, account: null, reason: "no-usable-target" };
         try {
           await performSwap(best);
@@ -257,7 +269,7 @@ export async function evaluateAndMaybeSwap(now = Date.now(), anticipatory = fals
       }
     }
 
-    const landed = await chooseAndSwap({ now, thresholds: effectiveBars(cfg), switchFamilies });
+    const landed = await chooseAndSwap({ now, thresholds: effectiveBars(cfg), switchFamilies, currentAccountUuid: seatOf(loadAccounts())?.accountUuid ?? null });
     if (landed) return { swapped: true, account: landed, reason: "swapped" };
 
     // Every account is depleted. Wait for whichever recovers soonest (including
@@ -267,8 +279,8 @@ export async function evaluateAndMaybeSwap(now = Date.now(), anticipatory = fals
     // dead account and the loop terminates (mirrors the greedy loop above).
     while (true) {
       const fresh = loadAccounts();
-      const ctx = { now, thresholds: effectiveBars(cfg), currentAccountUuid: fresh.activeAccountUuid, switchFamilies };
-      const current = fresh.accounts.find((a) => a.accountUuid === fresh.activeAccountUuid);
+      const current = seatOf(fresh);
+      const ctx = { now, thresholds: effectiveBars(cfg), currentAccountUuid: current?.accountUuid ?? null, switchFamilies };
       const currentAt = current ? usableAt(current, ctx) : Number.POSITIVE_INFINITY;
       const other = pickEarliestReset(fresh.accounts, ctx);
 
@@ -283,7 +295,7 @@ export async function evaluateAndMaybeSwap(now = Date.now(), anticipatory = fals
         return { swapped: false, account: null, reason: "all-depleted", ...(Number.isFinite(waitUntil) ? { waitUntil } : {}) };
       }
 
-      const isCurrent = target.accountUuid === fresh.activeAccountUuid;
+      const isCurrent = target.accountUuid === (current?.accountUuid ?? null);
       if (!isCurrent && !anticipatory) {
         log("decide.depleted_no_park", { account: target.accountUuid.slice(0, 8), waitUntil });
         return { swapped: false, account: null, reason: "all-depleted", waitUntil };

--- a/src/lib/decide.ts
+++ b/src/lib/decide.ts
@@ -200,6 +200,17 @@ export async function evaluateAndMaybeSwap(now = Date.now(), anticipatory = fals
     const u2 = loadUsage() ?? usage;
     const mu2 = needsPerModel(u2, cfg) ? loadModelUsage() ?? mu : null;
 
+    // A live login whose org is KNOWN but outside the pool: do nothing - the
+    // codex org-guard analog. performSwap would refuse any swap over it (an
+    // unpooled credential's only copy must never be overwritten), and the
+    // seat fallback below must not stand in a stale pooled label for it: the
+    // depleted path could then park a supervised session against the LABELED
+    // account's reset while the running login is someone else entirely
+    // (pullfrog review catch, PR #33).
+    if (org2 != null && !idx.accounts.some((a) => a.organizationUuid === org2)) {
+      return { swapped: false, account: null, reason: "live-credential-not-in-pool" };
+    }
+
     // record the active account's aggregate usage so the picker + `status` see it.
     // Resolved by the LIVE org the guard just verified, never the
     // activeAccountUuid label: after a manual /login the label drifts (the

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -245,17 +245,71 @@ export function checkTimerHealthy(): boolean {
   );
 }
 
-function uninstallCheckTimer(): void {
+/** The manual deactivation command for a still-loaded timer, per platform. */
+export function timerDeactivationHint(): string {
+  if (process.platform === "darwin") {
+    return `launchctl bootout gui/$(id -u)/${LAUNCHD_LABEL}`;
+  }
+  return "systemctl --user disable --now tokenmaxxing-check.timer";
+}
+
+/** Is the launchd check job loaded? Exit contract verified on this machine
+ *  (macOS 26, 2026-07-20): `launchctl print` exits 0 for a loaded job and 113
+ *  for a missing one. Anything else - including a spawn failure or timeout -
+ *  is "unavailable": an unanswerable probe must never read as "not loaded". */
+function launchdJobLoaded(): "loaded" | "not-loaded" | "unavailable" {
+  const domain = launchdDomain();
+  if (domain == null) return "unavailable";
+  try {
+    const { exitCode } = Bun.spawnSync(["launchctl", "print", `${domain}/${LAUNCHD_LABEL}`], { stdout: "ignore", stderr: "ignore", timeout: 10_000 });
+    if (exitCode === 0) return "loaded";
+    return exitCode === 113 ? "not-loaded" : "unavailable";
+  } catch {
+    return "unavailable";
+  }
+}
+
+/** Is the systemd check timer active? Classification goes by the state
+ *  string, never the exit code: systemctl(1) documents only "0 if at least
+ *  one is active, non-zero otherwise" for is-active, but guarantees "unless
+ *  --quiet is specified, this will also print the current unit state to
+ *  standard output" (verified against the systemd manpage 2026-07-20). The
+ *  failure mode is container-verified (ubuntu:24.04 systemd, no user bus,
+ *  2026-07-20): a dead session bus prints NOTHING to stdout ("Failed to
+ *  connect to bus" goes to stderr, exit 1), so an empty or unrecognized
+ *  stdout is "unavailable" - "cannot ask" never reads as "inactive". */
+function systemdTimerActive(): "active" | "not-active" | "unavailable" {
+  try {
+    const proc = Bun.spawnSync(["systemctl", "--user", "is-active", "tokenmaxxing-check.timer"], { stdout: "pipe", stderr: "ignore", timeout: 10_000 });
+    const state = proc.stdout.toString().trim();
+    if (state === "active" || state === "activating" || state === "reloading") return "active";
+    if (state === "inactive" || state === "failed" || state === "deactivating" || state === "unknown" || state === "maintenance") return "not-active";
+    return "unavailable";
+  } catch {
+    return "unavailable";
+  }
+}
+
+/** True when the job is verifiably no longer loaded. A swallowed bootout
+ *  failure once meant a half-uninstalled state kept firing `tokenmaxxing
+ *  check` every 180s against a package that may be gone, silently
+ *  (closing-review catch): deactivation is checked, not assumed - a job seen
+ *  loaded must deactivate successfully, and an unanswerable probe (service
+ *  manager unusable) reports false rather than pretending it is gone. */
+function uninstallCheckTimer(): boolean {
   if (process.platform === "darwin") {
     const domain = launchdDomain();
-    if (domain != null) run(["launchctl", "bootout", `${domain}/${LAUNCHD_LABEL}`]);
+    const loaded = launchdJobLoaded();
+    const deactivated = loaded === "loaded" && domain != null ? run(["launchctl", "bootout", `${domain}/${LAUNCHD_LABEL}`]) : loaded === "not-loaded";
     rmSync(launchdPlist(), { force: true });
-    return;
+    return deactivated;
   }
-  run(["systemctl", "--user", "disable", "--now", "tokenmaxxing-check.timer"]);
+  const active = systemdTimerActive();
+  const deactivated = active === "active" ? run(["systemctl", "--user", "disable", "--now", "tokenmaxxing-check.timer"]) : active === "not-active";
   rmSync(join(paths.systemdUserDir, "tokenmaxxing-check.timer"), { force: true });
   rmSync(join(paths.systemdUserDir, "tokenmaxxing-check.service"), { force: true });
   run(["systemctl", "--user", "daemon-reload"]);
+  return deactivated;
 }
 
 /** The rc file of the user's login shell, or null when the shell is unknown.
@@ -318,11 +372,31 @@ export function findClaudeShadowers(rcText: string): ShellShadower[] {
   return out;
 }
 
-export function uninstallSupervisor(): void {
+/** Remove ONLY the marker-tagged PATH line this tool added; a hand-added
+ *  PATH entry without the marker is the user's own. A stale `# tokenmaxxing
+ *  PATH` line pointing at an emptied binDir is exactly how the supervisor
+ *  recursion incident started (see AGENTS.md), so uninstall must not leave
+ *  one behind (closing-review catch). Returns true when a line was removed. */
+export function removePathFromRc(rc: string): boolean {
+  if (!existsSync(rc)) return false;
+  const lines = readFileSync(rc, "utf8").split("\n");
+  const kept = lines.filter((line) => !line.includes(PATH_LINE_MARK));
+  if (kept.length === lines.length) return false;
+  writeFileAtomic(rc, kept.join("\n"));
+  return true;
+}
+
+const UninstallOutcomeSchema = z.object({ timerDeactivated: z.boolean(), pathLineRemoved: z.boolean() });
+export type UninstallOutcome = z.infer<typeof UninstallOutcomeSchema>;
+
+export function uninstallSupervisor(): UninstallOutcome {
   uninstallSettings();
-  uninstallCheckTimer();
+  const timerDeactivated = uninstallCheckTimer();
   uninstallCodexSupervisor();
   for (const f of [paths.supervisorLink, join(paths.binDir, "xx"), installedBin()]) {
     if (existsSync(f)) rmSync(f, { force: true });
   }
+  const rc = shellRcPath();
+  const pathLineRemoved = rc != null && removePathFromRc(rc);
+  return { timerDeactivated, pathLineRemoved };
 }

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,10 +1,12 @@
 // Append-only logging. NEVER logs secret material - callers must pass only
 // non-secret context (account uuids/emails, percentages, status strings).
 
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, renameSync, statSync } from "node:fs";
 import { dirname } from "node:path";
 import { z } from "zod";
 import { paths } from "./paths.ts";
+
+const LOG_MAX_BYTES = 5_000_000;
 
 /** Redact anything that looks like a token so an accidental pass-through can't leak. */
 function redact(s: string): string {
@@ -34,6 +36,13 @@ export function log(event: string, fields: Record<string, unknown> = {}): void {
       })
       .join(" ");
     mkdirSync(dirname(paths.logFile), { recursive: true });
+    // Rotation cap: the check timer logs every 180s and the serve daemon
+    // echoes every event, so an uncapped append-only file grows forever on a
+    // live install (closing-review critic gap). One .old generation bounds
+    // total disk at ~2x the cap; older history is disposable diagnostics.
+    if (existsSync(paths.logFile) && statSync(paths.logFile).size > LOG_MAX_BYTES) {
+      renameSync(paths.logFile, `${paths.logFile}.old`);
+    }
     appendFileSync(paths.logFile, `${new Date().toISOString()} ${event} ${line}\n`);
   } catch {
     // logging must never throw into a hook / supervisor path

--- a/src/lib/sample.ts
+++ b/src/lib/sample.ts
@@ -87,8 +87,33 @@ export async function probeParkedUsage(account: Account, opts: { ping?: boolean 
     return { ok: false, reason: `parked credential unreadable (${(e instanceof Error ? e.message : String(e)).slice(0, 80)}) - run \`tokenmaxxing auth\`` };
   }
 
+  // The parked copy must never be refreshed (or probed - the probe can rotate
+  // it too) while its account secretly owns the LIVE login: after a crash
+  // between performSwap's live install and the oauthAccount rewrite, status
+  // still routes the live account here, and a parked-side rotation would
+  // supersede the live item's single-use refresh token out from under the
+  // running session - or, if claude rotated first, falsely flag the healthy
+  // live account needsReauth (closing-review catch; mirrors the codex
+  // sampler's present-account invariant). Verified against the live blob's
+  // TRUE org, fail-closed like the rm guard: an unverifiable live owner
+  // refuses the sample rather than risking the live grant.
+  const liveRaw = await readItem(liveTarget());
+  if (liveRaw != null) {
+    let liveOrg: string;
+    try {
+      const liveCreds = CredentialBlobSchema.parse(JSON.parse(liveRaw)).claudeAiOauth;
+      liveOrg = (await fetchTokenOrg(liveCreds.accessToken)).organization_uuid;
+    } catch (e) {
+      return { ok: false, reason: `cannot verify the live credential's owner (${(e instanceof Error ? e.message : String(e)).slice(0, 80)}) - refusing to sample a possibly-live account` };
+    }
+    if (liveOrg === account.organizationUuid) {
+      return { ok: false, reason: "this account holds the LIVE login (active label drifted) - run `tokenmaxxing switch` to reconcile" };
+    }
+  }
+
   // Hand claude a token with comfortable headroom so it won't run its own refresh
-  // (which claude does within 120s of expiry). Refresh + persist ourselves first.
+  // (which claude does within 300s of expiry - the same margin checked here).
+  // Refresh + persist ourselves first.
   if (isAccessTokenExpiring(creds, 300_000)) {
     try {
       creds = await refreshCredential(creds);

--- a/src/lib/slackbridge.ts
+++ b/src/lib/slackbridge.ts
@@ -74,7 +74,7 @@ export type ParkPlan = z.infer<typeof ParkPlanSchema>;
  *  will-resume promise - slaude's recorded rationale). The deadline is fixed
  *  when the message's relay starts, so chained parks can never hold the queue
  *  slot longer than PARK_MAX_MS in total. */
-export function parkPlan(input: { decision: SwapDecision; now: number; recoveries: number; deadline: number }): ParkPlan {
+export function parkPlan(input: { decision: SwapDecision; recoveries: number; deadline: number }): ParkPlan {
   const depleted = input.decision.reason === "all-depleted" || input.decision.reason === "depleted-wait";
   if (!depleted) return { kind: "proceed" };
   const wake = input.decision.waitUntil ?? null;
@@ -604,7 +604,7 @@ export async function relayThread(input: {
       await push(`tokenmaxxing: turn failed: ${detail}`);
       break;
     }
-    const plan = parkPlan({ decision, now: Date.now(), recoveries, deadline: parkDeadline });
+    const plan = parkPlan({ decision, recoveries, deadline: parkDeadline });
     if (plan.kind === "drop") {
       outcome.failed = true;
       outcome.rateLimited = true;

--- a/src/lib/slackstate.ts
+++ b/src/lib/slackstate.ts
@@ -4,6 +4,13 @@
 // claude session id + cwd a Slack thread resumes into (resume is cwd-keyed, so
 // the cwd must stay byte-stable for the thread's whole life). A present but
 // unparseable slack.json THROWS (no silent empty config); absent = null.
+//
+// Retention tradeoff (intentional, closing-review critic gap): thread records
+// have NO age-out - the only GC is the model-invoked finish_thread close-out.
+// An abandoned thread's record persists indefinitely, ON PURPOSE: records are
+// tiny JSON, every record is a resumable conversation, and a time-based
+// reaper would silently kill threads the user still expects to revive with
+// one @mention. Revisit only if slack-threads/ ever measurably bloats.
 
 import { existsSync, readFileSync, readdirSync, unlinkSync } from "node:fs";
 import { join } from "node:path";

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -56,8 +56,47 @@ export const ConfigFileSchema = z
   })
   .partial();
 
-export function loadConfig(): Config {
+const MergeOutcomeSchema = z.union([
+  z.object({ ok: z.literal(true), config: ConfigSchema }),
+  z.object({ ok: z.literal(false), detail: z.string() }),
+]);
+export type MergeOutcome = z.infer<typeof MergeOutcomeSchema>;
+
+/** Merge a validated sparse file over the defaults, apply the env binary
+ *  overrides, and validate the merged WHOLE (the projectionMargin-vs-
+ *  thresholds refine). Shared by loadConfig and `xx config set`: set must
+ *  reject a value whose merged result would make every later loadConfig
+ *  throw, silently disabling status/switch/hooks/statusline until the file is
+ *  hand-repaired (closing-review catch). */
+export function mergeConfigFile(p: z.infer<typeof ConfigFileSchema>): MergeOutcome {
   const cfg: Config = { ...DEFAULT_CONFIG, thresholds: { ...DEFAULT_CONFIG.thresholds }, policy: { ...DEFAULT_CONFIG.policy } };
+  cfg.thresholds.session = p.thresholds?.session ?? cfg.thresholds.session;
+  cfg.thresholds.weekly = p.thresholds?.weekly ?? cfg.thresholds.weekly;
+  cfg.claudeBin = p.claudeBin ?? cfg.claudeBin;
+  cfg.codexBin = p.codexBin ?? cfg.codexBin;
+  cfg.policy.projectionMargin = p.policy?.projectionMargin ?? cfg.policy.projectionMargin;
+  cfg.policy.greedySessionFloor = p.policy?.greedySessionFloor ?? cfg.policy.greedySessionFloor;
+  cfg.policy.usagePollTtlMs = p.policy?.usagePollTtlMs ?? cfg.policy.usagePollTtlMs;
+  cfg.policy.maxWaitMs = p.policy?.maxWaitMs ?? cfg.policy.maxWaitMs;
+  if (p.policy?.switchModels) {
+    cfg.policy.switchModels = p.policy.switchModels.map((s) => s.toLowerCase());
+  }
+  // env overrides win for the real binaries (tests / relocation)
+  const envBin = realClaudeBinFromEnv();
+  if (envBin) cfg.claudeBin = envBin;
+  const envCodexBin = realCodexBinFromEnv();
+  if (envCodexBin) cfg.codexBin = envCodexBin;
+  const merged = ConfigSchema.safeParse(cfg);
+  if (!merged.success) {
+    // per-field values passed but the merged whole is unusable (the
+    // projectionMargin-vs-thresholds refine); name the reason, not a zod dump.
+    return { ok: false, detail: merged.error.issues.map((issue) => issue.message).join("; ") };
+  }
+  return { ok: true, config: merged.data };
+}
+
+export function loadConfig(): Config {
+  let fileData: z.infer<typeof ConfigFileSchema> = {};
   if (existsSync(paths.configJson)) {
     let raw: unknown;
     try {
@@ -75,36 +114,26 @@ export function loadConfig(): Config {
       const fields = parsed.error.issues.map((issue) => issue.path.join(".")).join(", ");
       throw new Error(`${paths.configJson} has wrong-typed values (${fields}) - fix or remove them`);
     }
-    const p = parsed.data;
-    cfg.thresholds.session = p.thresholds?.session ?? cfg.thresholds.session;
-    cfg.thresholds.weekly = p.thresholds?.weekly ?? cfg.thresholds.weekly;
-    cfg.claudeBin = p.claudeBin ?? cfg.claudeBin;
-    cfg.codexBin = p.codexBin ?? cfg.codexBin;
-    cfg.policy.projectionMargin = p.policy?.projectionMargin ?? cfg.policy.projectionMargin;
-    cfg.policy.greedySessionFloor = p.policy?.greedySessionFloor ?? cfg.policy.greedySessionFloor;
-    cfg.policy.usagePollTtlMs = p.policy?.usagePollTtlMs ?? cfg.policy.usagePollTtlMs;
-    cfg.policy.maxWaitMs = p.policy?.maxWaitMs ?? cfg.policy.maxWaitMs;
-    if (p.policy?.switchModels) {
-      cfg.policy.switchModels = p.policy.switchModels.map((s) => s.toLowerCase());
-    }
+    fileData = parsed.data;
   }
-  // env overrides win for the real binaries (tests / relocation)
-  const envBin = realClaudeBinFromEnv();
-  if (envBin) cfg.claudeBin = envBin;
-  const envCodexBin = realCodexBinFromEnv();
-  if (envCodexBin) cfg.codexBin = envCodexBin;
-  const merged = ConfigSchema.safeParse(cfg);
-  if (!merged.success) {
-    // per-field values passed but the merged whole is unusable (the
-    // projectionMargin-vs-thresholds refine); name the reason, not a zod dump.
-    const detail = merged.error.issues.map((issue) => issue.message).join("; ");
-    throw new Error(`${paths.configJson} is invalid: ${detail} - fix or remove the offending values`);
-  }
-  return merged.data;
+  const outcome = mergeConfigFile(fileData);
+  if (!outcome.ok) throw new Error(`${paths.configJson} is invalid: ${outcome.detail} - fix or remove the offending values`);
+  return outcome.config;
 }
 
-export function saveConfig(c: Config): void {
-  writeFileAtomic(paths.configJson, JSON.stringify(ConfigSchema.parse(c), null, 2) + "\n");
+/** Pin one binary path into the SPARSE config file, preserving every other
+ *  override verbatim. Never write the merged config here: baking defaults (or
+ *  an ambient TOKENMAXXING_*_BIN env override) into the file freezes future
+ *  default changes as stale explicit values and misreports every `xx config`
+ *  source as "file" (closing-review catch; the sparse-overrides contract is
+ *  config.ts's header). Throws on a corrupt file, like loadConfig. */
+export function pinBinOverride(input: { key: "claudeBin" | "codexBin"; bin: string }): void {
+  let raw: Record<string, unknown> = {};
+  if (existsSync(paths.configJson)) {
+    raw = z.record(z.string(), z.unknown()).parse(JSON.parse(readFileSync(paths.configJson, "utf8")));
+  }
+  raw[input.key] = input.bin;
+  writeFileAtomic(paths.configJson, JSON.stringify(raw, null, 2) + "\n");
 }
 
 // ---- accounts.json -------------------------------------------------------
@@ -221,7 +250,8 @@ export function writeUsage(next: UsageState): boolean {
     } catch (e) {
       // The file vanished mid-race: a concurrent swap just invalidated these
       // figures. Suppressing stays correct; a write would resurrect them.
-      if ((e as { code?: string }).code !== "ENOENT") throw e;
+      const errno = z.object({ code: z.string() }).safeParse(e);
+      if (!errno.success || errno.data.code !== "ENOENT") throw e;
     }
     return false;
   }

--- a/src/lib/swap.ts
+++ b/src/lib/swap.ts
@@ -184,12 +184,17 @@ export async function performSwap(target: Account): Promise<void> {
  * Assumes the caller holds the flock (does NOT lock - avoids same-process
  * flock self-deadlock). Returns the account landed on, or null if none usable.
  */
-export async function chooseAndSwap(ctx: Omit<PickCtx, "currentAccountUuid">): Promise<Account | null> {
+export async function chooseAndSwap(ctx: PickCtx): Promise<Account | null> {
+  // ctx.currentAccountUuid is the caller-resolved SEAT (decide.ts resolves it
+  // by the live org, label fallback): resolving here off activeAccountUuid
+  // re-imported the label drift the caller just resolved away, and under
+  // drift the LIVE account could be picked as its own swap target (bugbot
+  // review catch, PR #33).
   const tried = new Set<string>();
   while (true) {
     const idx = loadAccounts();
     const candidates = idx.accounts.filter((a) => !tried.has(a.accountUuid));
-    const best = pickBest(candidates, { ...ctx, currentAccountUuid: idx.activeAccountUuid });
+    const best = pickBest(candidates, ctx);
     if (!best) return null;
     tried.add(best.accountUuid);
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,9 @@
 // `claude` (or `__supervise`), routes hook/statusLine subcommands, and otherwise
 // dispatches the `tokenmaxxing` CLI.
 
+import { existsSync } from "node:fs";
 import { basename } from "node:path";
+import { paths } from "./lib/paths.ts";
 import { runSupervisor } from "./entries/supervisor.ts";
 import { runStatusline } from "./entries/statusline.ts";
 import { runSubagentStatusline } from "./entries/subagentstatusline.ts";
@@ -27,7 +29,7 @@ import { cmdSwitch } from "./cli/switch.ts";
 import { cmdCheck } from "./cli/check.ts";
 import { cmdConfig } from "./cli/config.ts";
 import { cmdServe } from "./cli/serve.ts";
-import { uninstallSupervisor } from "./lib/install.ts";
+import { timerDeactivationHint, uninstallSupervisor } from "./lib/install.ts";
 import { c } from "./cli/render.ts";
 
 function printHelp(): void {
@@ -81,7 +83,13 @@ async function main(): Promise<number> {
     case "__codex-stop-hook": return runCodexStopHook();
     case undefined: return cmdStatus(); // bare `tokenmaxxing` / `xx` → status
     case "--force": return cmdStatus(true); // bare `xx --force` → status --force
-    case "switch": return args[1] === "--codex" ? cmdCodexSwitch(args[2]) : cmdSwitch(args[1]);
+    // --codex accepted anywhere, like init/add/status: the old args[1]-only
+    // check made `xx switch <sel> --codex` silently run a real CLAUDE swap
+    // (one email can hold both pools' accounts - closing-review catch).
+    case "switch": {
+      const rest = args.slice(1).filter((a) => a !== "--codex");
+      return args.includes("--codex") ? cmdCodexSwitch(rest[0]) : cmdSwitch(rest[0]);
+    }
     case "check": return cmdCheck();
     case "config": return cmdConfig(args.slice(1));
     case "serve": return cmdServe(args.slice(1));
@@ -94,10 +102,14 @@ async function main(): Promise<number> {
     case "doctor": return cmdDoctor();
     case "rm": return cmdRm(args[1]);
     case "rename": return cmdRename(args.slice(1));
-    case "uninstall":
-      uninstallSupervisor();
-      console.log("removed supervisor wrapper + settings entries (accounts/credentials kept)");
+    case "uninstall": {
+      const out = uninstallSupervisor();
+      console.log("removed supervisor wrapper, settings entries, check timer, and the rc PATH line");
+      if (!out.timerDeactivated) console.log(c.yellow(`⚠ the check job may still be loaded - run: ${timerDeactivationHint()}`));
+      if (!out.pathLineRemoved) console.log(c.dim("(no tokenmaxxing PATH line found in the shell rc)"));
+      console.log(`kept: accounts.json, config.json${existsSync(paths.slackJson) ? ", slack.json (Slack tokens)" : ""}, and every parked credential (macOS: keychain items, Linux: creds/) - remove accounts with \`xx rm\` to delete their credentials`);
       return 0;
+    }
     case "help":
     case "-h":
     case "--help":

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,16 @@ async function main(): Promise<number> {
     case "rename": return cmdRename(args.slice(1));
     case "uninstall": {
       const out = uninstallSupervisor();
-      console.log("removed supervisor wrapper, settings entries, check timer, and the rc PATH line");
+      // the headline lists only what verifiably happened - claiming the timer
+      // or PATH line gone while the outcome flags say otherwise would
+      // contradict the warnings below (bugbot review catch, PR #33).
+      const removed = [
+        "supervisor wrapper",
+        "settings entries",
+        ...(out.timerDeactivated ? ["check timer"] : []),
+        ...(out.pathLineRemoved ? ["rc PATH line"] : []),
+      ];
+      console.log(`removed ${removed.join(", ")}`);
       if (!out.timerDeactivated) console.log(c.yellow(`⚠ the check job may still be loaded - run: ${timerDeactivationHint()}`));
       if (!out.pathLineRemoved) console.log(c.dim("(no tokenmaxxing PATH line found in the shell rc)"));
       console.log(`kept: accounts.json, config.json${existsSync(paths.slackJson) ? ", slack.json (Slack tokens)" : ""}, and every parked credential (macOS: keychain items, Linux: creds/) - remove accounts with \`xx rm\` to delete their credentials`);

--- a/test/claudebin.test.ts
+++ b/test/claudebin.test.ts
@@ -14,7 +14,6 @@ import {
   wrapperEntryRateTripped,
 } from "../src/lib/claudebin.ts";
 import { paths } from "../src/lib/paths.ts";
-import { saveConfig } from "../src/lib/state.ts";
 
 const cfg = (claudeBin: string) => ({
   thresholds: { session: 95, weekly: 98 },
@@ -22,6 +21,8 @@ const cfg = (claudeBin: string) => ({
   codexBin: "",
   policy: { projectionMargin: 0, greedySessionFloor: 50, switchModels: ["fable"], usagePollTtlMs: 90_000, maxWaitMs: 3_600_000 },
 });
+
+const writeConfig = (config: unknown) => writeFileSync(paths.configJson, JSON.stringify(config));
 
 function writeExecutable(path: string, body: string): void {
   writeFileSync(path, body);
@@ -55,7 +56,7 @@ describe("pointsBackAtUs / resolveRealClaude identity guard", () => {
   test("a claudeBin pinned to the installed wrapper throws instead of recursing", () => {
     mkdirSync(paths.binDir, { recursive: true });
     writeExecutable(paths.supervisorLink, "#!/bin/sh\nexit 0\n");
-    saveConfig(cfg(paths.supervisorLink));
+    writeConfig(cfg(paths.supervisorLink));
     expect(pointsBackAtUs(paths.supervisorLink)).toBe(true);
     expect(() => resolveRealClaude()).toThrow(/own wrapper/);
   });
@@ -66,13 +67,13 @@ describe("pointsBackAtUs / resolveRealClaude identity guard", () => {
     writeExecutable(paths.supervisorLink, "#!/bin/sh\nexit 0\n");
     const link = join(scratch, "claude");
     symlinkSync(paths.supervisorLink, link);
-    saveConfig(cfg(link));
+    writeConfig(cfg(link));
     expect(pointsBackAtUs(link)).toBe(true);
     expect(() => resolveRealClaude()).toThrow(/own wrapper/);
   });
 
   test("a real binary outside binDir resolves", () => {
-    saveConfig(cfg("/usr/bin/true"));
+    writeConfig(cfg("/usr/bin/true"));
     expect(pointsBackAtUs("/usr/bin/true")).toBe(false);
     expect(resolveRealClaude()).toBe("/usr/bin/true");
   });
@@ -152,7 +153,7 @@ describe("resolveVerifiedClaude", () => {
     mkdirSync(goodDir, { recursive: true });
     writeExecutable(paths.supervisorLink, "#!/bin/sh\nexit 0\n");
     writeExecutable(join(goodDir, "claude"), `#!/bin/sh\necho "2.1.207 (Claude Code)"\n`);
-    saveConfig(cfg(paths.supervisorLink));
+    writeConfig(cfg(paths.supervisorLink));
     process.env.PATH = goodDir;
     expect(resolveVerifiedClaude()).toBe(join(goodDir, "claude"));
   });

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -142,6 +142,20 @@ describe("codex identity + auth blobs", () => {
     expect(() => codexIdentityOf({ auth })).toThrow(/no account id/);
   });
 
+  test("an api-key auth.json (tokens omitted or null) reads as no poolable login; corrupt still throws", () => {
+    // `codex login --with-api-key` writes `tokens` OMITTED (serde
+    // skip_serializing_if on Option<TokenData>, source-verified at
+    // rust-v0.144.5): a valid codex state the real binary runs on, so the
+    // shim and `xx status` must not crash on it - there is just nothing to
+    // pool (closing-review catch). Genuine corruption keeps throwing.
+    writeFileSync(codexPaths.authJson, JSON.stringify({ OPENAI_API_KEY: "sk-test" }));
+    expect(readLiveCodexAuth()).toBeNull();
+    writeFileSync(codexPaths.authJson, JSON.stringify({ OPENAI_API_KEY: "sk-test", tokens: null }));
+    expect(readLiveCodexAuth()).toBeNull();
+    writeFileSync(codexPaths.authJson, "{ not json");
+    expect(() => readLiveCodexAuth()).toThrow();
+  });
+
   test("parked round-trip preserves unknown siblings verbatim", () => {
     const auth = authBlob("A");
     writeParkedCodexAuth({ credFile: "tokenmaxxing-codex-test", auth });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -123,6 +123,22 @@ describe("config invariants", () => {
     writeFileSync(paths.configJson, JSON.stringify({ policy: { projectionMargin: 94 } }));
     expect(loadConfig().policy.projectionMargin).toBe(94);
   });
+  test("config set rejects a value whose MERGED config would brick loadConfig", () => {
+    // The per-field 0-100 bound passes 96, but merged against the default
+    // session threshold 95 the refine fails - without the merged gate this
+    // write made every later loadConfig throw, silently disabling
+    // status/switch/hooks until hand-repaired (closing-review catch).
+    writeFileSync(paths.configJson, JSON.stringify({}));
+    const errs: string[] = [];
+    const spy = spyOn(console, "error").mockImplementation((line: string) => { errs.push(line); });
+    try {
+      expect(cmdConfig(["set", "policy.projectionMargin", "96"])).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(errs.join(" ")).toContain("projectionMargin");
+    expect(loadConfig().policy.projectionMargin).toBe(0); // the file write never happened
+  });
 });
 
 describe("config env-source display", () => {

--- a/test/decide.test.ts
+++ b/test/decide.test.ts
@@ -13,7 +13,7 @@ import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { evaluateAndMaybeSwap } from "../src/lib/decide.ts";
 import { paths } from "../src/lib/paths.ts";
-import { loadAccounts, loadModelUsage, loadUsage, saveAccounts, saveDepletedWait, saveLastSwapAt } from "../src/lib/state.ts";
+import { loadAccounts, loadDepletedWait, loadModelUsage, loadUsage, saveAccounts, saveDepletedWait, saveLastSwapAt } from "../src/lib/state.ts";
 import { writeItem, parkedTarget, liveTarget, deleteItem } from "../src/lib/credstore.ts";
 import type { Account } from "../src/lib/types.ts";
 
@@ -262,6 +262,26 @@ describe("evaluateAndMaybeSwap headless snapshot handling", () => {
     const after = loadAccounts();
     expect(after.accounts.find((x) => x.accountUuid === "A")!.lastUsage?.fiveHour.usedPercentage).toBe(60);
     expect(after.accounts.find((x) => x.accountUuid === "B")!.lastUsage).toBeUndefined();
+  });
+
+  test("a KNOWN live org outside the pool stands down instead of seating the stale label", async () => {
+    // The user /login'd an account that was never pooled. The seat fallback
+    // must not stand in the stale labeled account: the depleted path could
+    // park a supervised session against the LABEL's reset while the running
+    // login is someone else entirely (pullfrog review catch, PR #33 - the
+    // codex live-credential-not-in-pool guard, mirrored).
+    installFakeClaude(10, Date.now() + 2 * D);
+    installFixtures();
+    writeFileSync(
+      paths.claudeJson,
+      JSON.stringify({ oauthAccount: { accountUuid: "X", emailAddress: "x@e.com", organizationUuid: "org-X" } }),
+    );
+    writeUsageJson({ org: "org-X", fiveHour: { usedPercentage: 97, resetsAt: Date.now() + 3_600_000 } });
+    const d = await evaluateAndMaybeSwap(Date.now(), true);
+    expect(d.reason).toBe("live-credential-not-in-pool");
+    expect(d.swapped).toBe(false);
+    // no depleted-wait was recorded against the stale label
+    expect(loadDepletedWait()).toBeNull();
   });
 
   test("split thresholds: a session window over its own bar triggers below the weekly bar", async () => {

--- a/test/decide.test.ts
+++ b/test/decide.test.ts
@@ -245,6 +245,26 @@ describe("evaluateAndMaybeSwap headless snapshot handling", () => {
     expect(d.reason).toBe("under-threshold-or-stale");
   });
 
+  test("the locked-section usage stamp lands on the LIVE org's account, never the drifted label", async () => {
+    // accounts.json's activeAccountUuid still names B (manual /login drift,
+    // the surviving drift source) while claude.json and the tee say org-A.
+    // Stamping by label wrote A's windows into B: the picker then screened
+    // and ranked B on A's numbers (closing-review catch). The greedy pick
+    // afterwards fails loudly on A's missing parked credential - expected,
+    // the stamp is persisted before it.
+    installFakeClaude(10, Date.now() + 2 * D);
+    installFixtures([poolAccount("B")]);
+    saveAccounts({ version: 1, activeAccountUuid: "B", accounts: [poolAccount("A"), poolAccount("B")] });
+    writeUsageJson({ fiveHour: { usedPercentage: 60, resetsAt: Date.now() + 3_600_000 } });
+    // the specific expected failure, nothing else: the greedy pick reaches
+    // performSwap(A) and dies on A's absent parked credential - any OTHER
+    // rejection (or none) means the decision took an unexpected path.
+    await expect(evaluateAndMaybeSwap(Date.now(), false)).rejects.toThrow("no parked credential for A@e.com");
+    const after = loadAccounts();
+    expect(after.accounts.find((x) => x.accountUuid === "A")!.lastUsage?.fiveHour.usedPercentage).toBe(60);
+    expect(after.accounts.find((x) => x.accountUuid === "B")!.lastUsage).toBeUndefined();
+  });
+
   test("split thresholds: a session window over its own bar triggers below the weekly bar", async () => {
     installFakeClaude(50, Date.now() + 2 * D);
     installFixtures([], { session: 95, weekly: 98 });

--- a/test/decide.test.ts
+++ b/test/decide.test.ts
@@ -245,21 +245,20 @@ describe("evaluateAndMaybeSwap headless snapshot handling", () => {
     expect(d.reason).toBe("under-threshold-or-stale");
   });
 
-  test("the locked-section usage stamp lands on the LIVE org's account, never the drifted label", async () => {
+  test("under label drift both the usage stamp AND the greedy seat resolve by the LIVE org", async () => {
     // accounts.json's activeAccountUuid still names B (manual /login drift,
     // the surviving drift source) while claude.json and the tee say org-A.
-    // Stamping by label wrote A's windows into B: the picker then screened
-    // and ranked B on A's numbers (closing-review catch). The greedy pick
-    // afterwards fails loudly on A's missing parked credential - expected,
-    // the stamp is persisted before it.
+    // Stamping by label wrote A's windows into B, and the label-resolved seat
+    // then judged B as "current" - ranking on the wrong cached windows and
+    // offering the LIVE account as a swap target (closing-review + bugbot
+    // catches). With both resolved by live org: A gets the stamp, A wins its
+    // own seat, and the decision is a clean no-swap current-best.
     installFakeClaude(10, Date.now() + 2 * D);
     installFixtures([poolAccount("B")]);
     saveAccounts({ version: 1, activeAccountUuid: "B", accounts: [poolAccount("A"), poolAccount("B")] });
     writeUsageJson({ fiveHour: { usedPercentage: 60, resetsAt: Date.now() + 3_600_000 } });
-    // the specific expected failure, nothing else: the greedy pick reaches
-    // performSwap(A) and dies on A's absent parked credential - any OTHER
-    // rejection (or none) means the decision took an unexpected path.
-    await expect(evaluateAndMaybeSwap(Date.now(), false)).rejects.toThrow("no parked credential for A@e.com");
+    const d = await evaluateAndMaybeSwap(Date.now(), false);
+    expect(d.reason).toBe("current-best"); // the live account holds the seat; never-sampled B ranks last
     const after = loadAccounts();
     expect(after.accounts.find((x) => x.accountUuid === "A")!.lastUsage?.fiveHour.usedPercentage).toBe(60);
     expect(after.accounts.find((x) => x.accountUuid === "B")!.lastUsage).toBeUndefined();

--- a/test/e2e/swap-concurrency.ts
+++ b/test/e2e/swap-concurrency.ts
@@ -30,7 +30,7 @@ process.env.TOKENMAXXING_OAUTH_ROLES_URL = "http://127.0.0.1:8792/roles";
 process.env.NO_COLOR = "1";
 
 const { writeItem, readItem, deleteItem, liveTarget, parkedTarget } = await import("../../src/lib/credstore.ts");
-const { saveAccounts, loadAccounts, saveConfig } = await import("../../src/lib/state.ts");
+const { saveAccounts, loadAccounts } = await import("../../src/lib/state.ts");
 const { evaluateAndMaybeSwap } = await import("../../src/lib/decide.ts");
 import type { Account, UsageState } from "../../src/lib/types.ts";
 
@@ -91,7 +91,7 @@ async function seed() {
   // claudeBin makes resolveRealClaude fail (it must never PATH-scan its way
   // to the installed tokenmaxxing wrapper and recurse).
   // both bars at 95: the seeded windows (5h 97, Fable 96) target a single bar.
-  saveConfig({ thresholds: { session: 95, weekly: 95 }, claudeBin: "/usr/bin/true", codexBin: "", policy: { projectionMargin: 0, greedySessionFloor: 50, switchModels: ["fable", "opus"], usagePollTtlMs: 90_000, maxWaitMs: 3_600_000 } });
+  writeFileSync(process.env.TOKENMAXXING_HOME + "/config.json", JSON.stringify({ thresholds: { session: 95, weekly: 95 }, claudeBin: "/usr/bin/true", codexBin: "", policy: { projectionMargin: 0, greedySessionFloor: 50, switchModels: ["fable", "opus"], usagePollTtlMs: 90_000, maxWaitMs: 3_600_000 } }));
   await writeItem(parkedTarget(CRED_A), blob("A"));
   await writeItem(parkedTarget(CRED_B), blob("B"));
   await writeItem(liveTarget(), blob("A")); // A is live

--- a/test/init-usage.test.ts
+++ b/test/init-usage.test.ts
@@ -3,7 +3,22 @@
 // (bare claude, xx, xx status --force, add, switch).
 
 import { expect, spyOn, test } from "bun:test";
-import { printUsage } from "../src/cli/init.ts";
+import { rmSync, writeFileSync } from "node:fs";
+import { cmdInit, printUsage } from "../src/cli/init.ts";
+import { paths } from "../src/lib/paths.ts";
+
+test("init fails fast on a merged-invalid config instead of claiming a repair", async () => {
+  // pinBinOverride writes sparsely without validating, so without the
+  // explicit loadConfig gate a re-init printed success while every later
+  // loadConfig (hooks, switching, statusline) kept throwing until the file
+  // was hand-repaired (bugbot review catch, PR #33).
+  writeFileSync(paths.configJson, JSON.stringify({ policy: { projectionMargin: 96 } }));
+  try {
+    await expect(cmdInit()).rejects.toThrow("is invalid");
+  } finally {
+    rmSync(paths.configJson, { force: true });
+  }
+});
 
 test("init epilogue teaches the xx shorthand and the core commands", () => {
   const lines: string[] = [];

--- a/test/installrc.test.ts
+++ b/test/installrc.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { ensurePathInRc, findClaudeShadowers, shellRcPath } from "../src/lib/install.ts";
+import { ensurePathInRc, findClaudeShadowers, removePathFromRc, shellRcPath } from "../src/lib/install.ts";
 import { paths } from "../src/lib/paths.ts";
 
 const base = globalThis.__TM_TEST_BASE__!;
@@ -44,6 +44,22 @@ describe("shell rc PATH line", () => {
     const lines = readFileSync(rc, "utf8").split("\n");
     expect(lines[0]).toBe("alias ll='ls -la'");
     expect(lines[1]).toContain("# tokenmaxxing PATH");
+  });
+
+  test("removePathFromRc removes ONLY the marked line and reports honestly", () => {
+    // A stale marked line pointing at an emptied binDir is the recursion-
+    // incident vector uninstall must not leave behind; a hand-added PATH line
+    // without the marker is the user's own (deletion scope is literal).
+    const rc = join(base, "rc-remove");
+    writeFileSync(rc, `alias ll='ls -la'\nexport PATH="/user/own/bin:$PATH"\n`);
+    ensurePathInRc(rc);
+    expect(removePathFromRc(rc)).toBe(true);
+    const after = readFileSync(rc, "utf8");
+    expect(after).not.toContain("# tokenmaxxing PATH");
+    expect(after).toContain("alias ll='ls -la'");
+    expect(after).toContain(`export PATH="/user/own/bin:$PATH"`);
+    expect(removePathFromRc(rc)).toBe(false); // nothing left to remove
+    expect(removePathFromRc(join(base, "rc-never-existed"))).toBe(false);
   });
 });
 

--- a/test/keychain.test.ts
+++ b/test/keychain.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { readItem, writeItem, deleteItem } from "../src/lib/keychain.ts";
 
 // keychain is macOS-only; skip elsewhere. Uses a throwaway service, never the
@@ -7,6 +7,17 @@ const it = process.platform === "darwin" ? test : test.skip;
 
 describe("keychain ps-safe I/O", () => {
   const target = { service: `tokenmaxxing-test-${process.pid}`, account: process.env.USER ?? "unknown" };
+  const bigTarget = { service: `tokenmaxxing-test-big-${process.pid}`, account: process.env.USER ?? "unknown" };
+
+  // The items live in the REAL login keychain, and the pid-unique names mean
+  // no later run ever reaps them: an assertion failing before the inline
+  // deleteItem would strand them forever (closing-review catch). afterAll
+  // deletes unconditionally; deleteItem on an already-removed item is a no-op.
+  afterAll(async () => {
+    if (process.platform !== "darwin") return;
+    await deleteItem(target);
+    await deleteItem(bigTarget);
+  });
   const blob = JSON.stringify({
     claudeAiOauth: {
       accessToken: "sk-ant-oat01_AbC-dEf_12/34+xyz==",
@@ -37,9 +48,8 @@ describe("keychain ps-safe I/O", () => {
       mcpOAuth: Object.fromEntries(Array.from({ length: 20 }, (_, i) => [`srv${i}`, { accessToken: "t".repeat(300), redirectUri: "http://localhost:3118/callback?utm_source=plugin" }])),
     });
     expect(big.length).toBeGreaterThan(4096);
-    const t2 = { service: `tokenmaxxing-test-big-${process.pid}`, account: process.env.USER ?? "unknown" };
-    await writeItem(t2, big);
-    expect(await readItem(t2)).toBe(big);
-    await deleteItem(t2);
+    await writeItem(bigTarget, big);
+    expect(await readItem(bigTarget)).toBe(big);
+    await deleteItem(bigTarget);
   });
 });

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -17,6 +17,16 @@ beforeAll(() => {
       if (lastBody.refresh_token === "BOOM") {
         return new Response("upstream exploded", { status: 500 });
       }
+      if (lastBody.refresh_token === "OMIT") {
+        // rotation omitted: the schema allows it, and the client must keep
+        // the previous refresh token instead of persisting undefined.
+        return Response.json({
+          access_token: "fresh-access-OMIT",
+          expires_in: 3600,
+          scope: "user:inference user:profile",
+          token_type: "Bearer",
+        });
+      }
       return Response.json({
         access_token: "fresh-access-" + lastBody.refresh_token,
         refresh_token: "rotated-" + lastBody.refresh_token,
@@ -56,10 +66,15 @@ describe("oauth refresh grant", () => {
   });
 
   test("reuses previous refresh token when server omits it", async () => {
-    // server always returns one; simulate omit by checking the fallback path directly
-    const creds = { ...base, refreshToken: "keep" };
+    // the OMIT sentinel makes the mock answer WITHOUT refresh_token: the old
+    // version of this test always got a rotation back, so the fallback at
+    // oauth.ts had zero coverage despite a test named for it (closing-review
+    // catch) - losing the fallback persists refreshToken: undefined over the
+    // account's parked backup and destroys its only grant.
+    const creds = { ...base, refreshToken: "OMIT" };
     const out = await refreshCredential(creds, 0);
-    expect(out.refreshToken).toBe("rotated-keep");
+    expect(out.accessToken).toBe("fresh-access-OMIT");
+    expect(out.refreshToken).toBe("OMIT");
   });
 
   test("invalid_grant throws InvalidGrantError", async () => {

--- a/test/ping.test.ts
+++ b/test/ping.test.ts
@@ -10,7 +10,6 @@ import { chmodSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync
 import { join } from "node:path";
 import { MAX_WRAP_DEPTH } from "../src/lib/claudebin.ts";
 import { paths } from "../src/lib/paths.ts";
-import { saveConfig } from "../src/lib/state.ts";
 import { pingSession } from "../src/lib/usage.ts";
 
 const scratch = join(paths.home, "ping-test");
@@ -23,7 +22,7 @@ function installFakeClaude(body: string): void {
   const fake = join(scratch, "claude");
   writeFileSync(fake, `#!/bin/sh\nprintf '%s\\n' "$@" > ${JSON.stringify(argsFile)}\nenv > ${JSON.stringify(envFile)}\npwd > ${JSON.stringify(cwdFile)}\n${body}\n`);
   chmodSync(fake, 0o755);
-  saveConfig({ thresholds: { session: 95, weekly: 98 }, claudeBin: fake, codexBin: "", policy: { projectionMargin: 0, greedySessionFloor: 50, switchModels: ["fable"], usagePollTtlMs: 90_000, maxWaitMs: 3_600_000 } });
+  writeFileSync(paths.configJson, JSON.stringify({ thresholds: { session: 95, weekly: 98 }, claudeBin: fake, codexBin: "", policy: { projectionMargin: 0, greedySessionFloor: 50, switchModels: ["fable"], usagePollTtlMs: 90_000, maxWaitMs: 3_600_000 } }));
 }
 
 afterEach(() => {

--- a/test/probe-hang.test.ts
+++ b/test/probe-hang.test.ts
@@ -8,7 +8,6 @@ import { afterAll, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { paths } from "../src/lib/paths.ts";
-import { saveConfig } from "../src/lib/state.ts";
 import { probeUsage } from "../src/lib/usage.ts";
 
 const scratch = join(paths.home, "probe-hang-test");
@@ -41,7 +40,7 @@ test(
     // exits immediately but leaves a background child holding the pipes open
     writeFileSync(fake, `#!/bin/sh\nsleep 30 &\necho $! >> ${JSON.stringify(sleeperPids)}\necho '{"result":"Current session: 10% used"}'\nexit 0\n`);
     chmodSync(fake, 0o755);
-    saveConfig({ thresholds: { session: 95, weekly: 98 }, claudeBin: fake, codexBin: "", policy: { projectionMargin: 0, greedySessionFloor: 50, switchModels: ["fable"], usagePollTtlMs: 90_000, maxWaitMs: 3_600_000 } });
+    writeFileSync(paths.configJson, JSON.stringify({ thresholds: { session: 95, weekly: 98 }, claudeBin: fake, codexBin: "", policy: { projectionMargin: 0, greedySessionFloor: 50, switchModels: ["fable"], usagePollTtlMs: 90_000, maxWaitMs: 3_600_000 } }));
 
     const started = Date.now();
     const result = await probeUsage();

--- a/test/pure.test.ts
+++ b/test/pure.test.ts
@@ -33,6 +33,24 @@ describe("supervisor argument analysis", () => {
     expect(bad.sessionId).toBe(null);
     expect(bad.manage).toBe(false); // pass through unmanaged; real claude rejects the id
   });
+  test("value-taking root flag values never read as the subcommand", () => {
+    // `--settings config` once flipped manage off because the VALUE token was
+    // mistaken for a subcommand and the session silently ran unmanaged
+    // (closing-review catch; the hardening shouldManageCodex already had).
+    expect(analyzeArgs(["--settings", "config"]).manage).toBe(true);
+    expect(analyzeArgs(["--append-system-prompt", "help"]).manage).toBe(true);
+    expect(analyzeArgs(["--add-dir", "agents", "mcp"]).manage).toBe(true); // variadic eats every non-dash follower
+    expect(analyzeArgs(["-d", "config"]).manage).toBe(true); // optional-value consumes a non-flag follower
+    expect(analyzeArgs(["--settings", "x", "mcp"]).manage).toBe(false); // a real subcommand still passes through
+  });
+  test("a forked resume passes through unmanaged (the fork mints a new sid)", () => {
+    // Managing it would pin marker paths to the stale pre-fork sid, and a
+    // respawn would fork yet another session off the old transcript
+    // (closing-review catch).
+    expect(analyzeArgs(["--resume", UUID, "--fork-session"]).manage).toBe(false);
+    expect(analyzeArgs(["-c", "--fork-session"]).manage).toBe(false);
+    expect(analyzeArgs(["--fork-session"]).manage).toBe(true); // inert without a resume
+  });
   test("stripSessionFlags removes only session selectors", () => {
     expect(stripSessionFlags(["--session-id", UUID, "--model", "opus"])).toEqual(["--model", "opus"]);
     expect(stripSessionFlags(["--resume", UUID, "foo"])).toEqual(["foo"]);

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -4,14 +4,14 @@ import { claudeExecutablePath, ensureBestAccount, pooledOptions, pooledSpawnEnv,
 import { MAX_WRAP_DEPTH, WRAP_DEPTH_ENV } from "../src/lib/claudebin.ts";
 import { CRED_ENV_OVERRIDES } from "../src/lib/usage.ts";
 import { paths } from "../src/lib/paths.ts";
-import { saveConfig } from "../src/lib/state.ts";
-
 const cfg = (claudeBin: string) => ({
   thresholds: { session: 95, weekly: 98 },
   claudeBin,
   codexBin: "",
   policy: { projectionMargin: 0, greedySessionFloor: 50, switchModels: ["fable"], usagePollTtlMs: 90_000, maxWaitMs: 3_600_000 },
 });
+
+const writeConfig = (config: unknown) => writeFileSync(paths.configJson, JSON.stringify(config));
 
 const MUTATED = [...CRED_ENV_OVERRIDES, "CLAUDE_CONFIG_DIR", WRAP_DEPTH_ENV, "TOKENMAXXING_SDK_TEST_PASSTHROUGH"];
 const saved: Record<string, string | undefined> = {};
@@ -63,7 +63,7 @@ describe("pooledSpawnEnv", () => {
 
 describe("pooledOptions", () => {
   test("pins pathToClaudeCodeExecutable to the resolved real claude", () => {
-    saveConfig(cfg("/usr/bin/true"));
+    writeConfig(cfg("/usr/bin/true"));
     expect(claudeExecutablePath()).toBe("/usr/bin/true");
     const opts = pooledOptions();
     expect(opts.pathToClaudeCodeExecutable).toBe("/usr/bin/true");
@@ -71,7 +71,7 @@ describe("pooledOptions", () => {
   });
 
   test("a configured-but-missing claudeBin fails fast instead of PATH-scanning", () => {
-    saveConfig(cfg("/nonexistent/claude"));
+    writeConfig(cfg("/nonexistent/claude"));
     expect(() => pooledOptions()).toThrow(/does not exist/);
   });
 });

--- a/test/servedaemon.test.ts
+++ b/test/servedaemon.test.ts
@@ -5,11 +5,13 @@
 // deps as inputs, so nothing here can bleed into other test files.
 
 import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
 import { delay } from "es-toolkit";
 import type { StreamChunk } from "chat";
 import { buildServeRuntime } from "../src/cli/serve.ts";
 import { cleanupThread, type TurnOutcome } from "../src/lib/slackbridge.ts";
-import { SlackConfigSchema, loadSlackThread } from "../src/lib/slackstate.ts";
+import { pidStartTime } from "../src/lib/proc.ts";
+import { SlackConfigSchema, loadSlackThread, saveSlackThread } from "../src/lib/slackstate.ts";
 
 const cfg = SlackConfigSchema.parse({
   botToken: "xoxb-test",
@@ -30,12 +32,12 @@ function runtimeWith(relay: Parameters<typeof buildServeRuntime>[0]["relay"]) {
   });
 }
 
-function fakeThread(input: { id: string; rejectPosts?: boolean }) {
+function fakeThread(input: { id: string; rejectPosts?: boolean; channelId?: string }) {
   const posted: string[] = [];
   const calls = { posts: 0, subscribe: 0, unsubscribe: 0, startTyping: 0 };
   const thread = {
     id: input.id,
-    channelId: "slack:C0DAEMON",
+    channelId: input.channelId ?? "slack:C0DAEMON",
     post: async (m: string | AsyncIterable<string | StreamChunk>) => {
       calls.posts += 1;
       if (input.rejectPosts) throw new Error("slack said no");
@@ -168,6 +170,23 @@ describe("buildServeRuntime drain", () => {
     expect(rt.activeTurns.size).toBe(0);
   });
 
+  test("an unlinked channel stays silent even while draining", async () => {
+    // the unlinked check runs BEFORE the drain branch: a drop notice posted
+    // into a log-only-silent channel would tell a user to resend a message
+    // that will never be served (closing-review catch).
+    let relayCalls = 0;
+    const rt = runtimeWith(async () => {
+      relayCalls += 1;
+      return okOutcome;
+    });
+    rt.beginDrain();
+    const t = fakeThread({ id: "slack:C0OTHER:402.1", channelId: "slack:C0OTHER" });
+    await rt.onMessage({ thread: t.thread, message: home("@UBOT hello"), skipped: [], isMention: true });
+    await flushTurns(rt);
+    expect(relayCalls).toBe(0);
+    expect(t.calls.posts).toBe(0);
+  });
+
   test("an ANNOUNCED drop during drain never leaves a resume marker (no double delivery)", async () => {
     // relayThread told the user to resend; replaying the turn at startup would
     // duplicate work, quota, and side effects on top of the user's resend.
@@ -194,6 +213,44 @@ describe("buildServeRuntime drain", () => {
     await rt.onMessage({ thread: t.thread, message: home("@UBOT long job"), skipped: [], isMention: true });
     await flushTurns(rt);
     expect(loadSlackThread("slack:C0DAEMON:701.1")?.activeTurn?.prompt).toContain("long job");
+  });
+});
+
+describe("buildServeRuntime crash-orphan reap", () => {
+  test("an inbound turn reaps a previous generation's surviving orphan before running", async () => {
+    // A real detached sleeper (its own process group, like the daemon's
+    // detached claude child) stands in for a SIGKILLed generation's orphan.
+    // Without the handleTurn reap, an inbound message winning the serialized
+    // chain ahead of startup recovery overwrote the marker and stranded the
+    // orphan's pid forever (closing-review HIGH catch).
+    const orphan = spawn("sleep", ["30"], { detached: true, stdio: "ignore" });
+    orphan.unref();
+    const pid = orphan.pid!;
+    let started: string | null = null;
+    for (let i = 0; i < 40 && started === null; i++) {
+      started = pidStartTime(pid);
+      if (started === null) await delay(50);
+    }
+    expect(started).not.toBeNull();
+    const threadId = "slack:C0DAEMON:800.1";
+    saveSlackThread({
+      threadId,
+      repo: "/tmp/serve-daemon-repo",
+      cwd: "/tmp/serve-daemon-repo",
+      sessionId: "s-orphan",
+      createdAt: new Date().toISOString(),
+      activeTurn: { prompt: "killed turn", startedAt: new Date().toISOString(), resumeCount: 0, pid, pidStartedAt: started! },
+    });
+    let relayCalls = 0;
+    const rt = runtimeWith(async () => {
+      relayCalls += 1;
+      return okOutcome;
+    });
+    const t = fakeThread({ id: threadId });
+    await rt.onMessage({ thread: t.thread, message: home("@UBOT follow-up"), skipped: [], isMention: true });
+    expect(relayCalls).toBe(1);
+    // the orphan was identity-verified and signaled before the new turn ran
+    expect(pidStartTime(pid)).not.toBe(started);
   });
 });
 

--- a/test/slackbridge.test.ts
+++ b/test/slackbridge.test.ts
@@ -17,12 +17,12 @@ const depleted = { swapped: false, account: null, reason: "all-depleted" };
 
 describe("parkPlan", () => {
   test("proceeds on a usable pool", () => {
-    expect(parkPlan({ decision: usable, now: NOW, recoveries: 0, deadline: DEADLINE })).toEqual({ kind: "proceed" });
-    expect(parkPlan({ decision: { ...usable, reason: "swapped" }, now: NOW, recoveries: 0, deadline: DEADLINE })).toEqual({ kind: "proceed" });
+    expect(parkPlan({ decision: usable, recoveries: 0, deadline: DEADLINE })).toEqual({ kind: "proceed" });
+    expect(parkPlan({ decision: { ...usable, reason: "swapped" }, recoveries: 0, deadline: DEADLINE })).toEqual({ kind: "proceed" });
   });
 
   test("parks slightly past a near recovery", () => {
-    const plan = parkPlan({ decision: { ...depleted, waitUntil: NOW + 60_000 }, now: NOW, recoveries: 0, deadline: DEADLINE });
+    const plan = parkPlan({ decision: { ...depleted, waitUntil: NOW + 60_000 }, recoveries: 0, deadline: DEADLINE });
     expect(plan.kind).toBe("park");
     if (plan.kind === "park") expect(plan.wakeAt).toBeGreaterThan(NOW + 60_000);
   });
@@ -30,19 +30,19 @@ describe("parkPlan", () => {
   test("the wake grace counts against the deadline", () => {
     // a reset in the final seconds of the budget would wake past the promised
     // total hold, so it drops instead of parking.
-    expect(parkPlan({ decision: { ...depleted, waitUntil: DEADLINE - 1_000 }, now: NOW, recoveries: 0, deadline: DEADLINE }).kind).toBe("drop");
-    expect(parkPlan({ decision: { ...depleted, waitUntil: DEADLINE - 60_000 }, now: NOW, recoveries: 0, deadline: DEADLINE }).kind).toBe("park");
+    expect(parkPlan({ decision: { ...depleted, waitUntil: DEADLINE - 1_000 }, recoveries: 0, deadline: DEADLINE }).kind).toBe("drop");
+    expect(parkPlan({ decision: { ...depleted, waitUntil: DEADLINE - 60_000 }, recoveries: 0, deadline: DEADLINE }).kind).toBe("park");
   });
 
   test("depleted-wait counts as depleted", () => {
-    const plan = parkPlan({ decision: { ...depleted, reason: "depleted-wait", waitUntil: NOW + 60_000 }, now: NOW, recoveries: 0, deadline: DEADLINE });
+    const plan = parkPlan({ decision: { ...depleted, reason: "depleted-wait", waitUntil: NOW + 60_000 }, recoveries: 0, deadline: DEADLINE });
     expect(plan.kind).toBe("park");
   });
 
   test("drops honestly on unknown or past-deadline recovery", () => {
-    expect(parkPlan({ decision: depleted, now: NOW, recoveries: 0, deadline: DEADLINE })).toEqual({ kind: "drop", recoversAt: null });
+    expect(parkPlan({ decision: depleted, recoveries: 0, deadline: DEADLINE })).toEqual({ kind: "drop", recoversAt: null });
     const far = DEADLINE + 60_000;
-    expect(parkPlan({ decision: { ...depleted, waitUntil: far }, now: NOW, recoveries: 0, deadline: DEADLINE })).toEqual({ kind: "drop", recoversAt: far });
+    expect(parkPlan({ decision: { ...depleted, waitUntil: far }, recoveries: 0, deadline: DEADLINE })).toEqual({ kind: "drop", recoversAt: far });
   });
 
   test("the deadline is SHARED across a message's parks, not per park", () => {
@@ -50,7 +50,7 @@ describe("parkPlan", () => {
     // would pass a per-park cap but exceeds the message's one deadline.
     const later = NOW + PARK_MAX_MS - 60_000;
     const secondWake = later + 600_000;
-    expect(parkPlan({ decision: { ...depleted, waitUntil: secondWake }, now: later, recoveries: 1, deadline: DEADLINE })).toEqual({
+    expect(parkPlan({ decision: { ...depleted, waitUntil: secondWake }, recoveries: 1, deadline: DEADLINE })).toEqual({
       kind: "drop",
       recoversAt: secondWake,
     });
@@ -58,7 +58,7 @@ describe("parkPlan", () => {
 
   test("the recovery budget caps parking even when the wake is near", () => {
     const soon = NOW + 60_000;
-    const plan = parkPlan({ decision: { ...depleted, waitUntil: soon }, now: NOW, recoveries: MAX_RECOVERIES, deadline: DEADLINE });
+    const plan = parkPlan({ decision: { ...depleted, waitUntil: soon }, recoveries: MAX_RECOVERIES, deadline: DEADLINE });
     expect(plan).toEqual({ kind: "drop", recoversAt: soon });
   });
 });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { loadAccounts, saveAccounts, loadConfig, saveConfig, loadDepletedWait, loadLastSwapAt, loadUsage, saveDepletedWait, usageTeeAt, writeUsage } from "../src/lib/state.ts";
+import { z } from "zod";
+import { loadAccounts, saveAccounts, loadConfig, loadDepletedWait, loadLastSwapAt, loadUsage, saveDepletedWait, usageTeeAt, writeUsage } from "../src/lib/state.ts";
 import { paths } from "../src/lib/paths.ts";
 import type { Account, UsageState } from "../src/lib/types.ts";
 
@@ -18,8 +19,8 @@ function acct(): Account {
 }
 
 describe("config round-trip", () => {
-  test("save/load preserves thresholds + policy", () => {
-    saveConfig({ thresholds: { session: 90, weekly: 93 }, claudeBin: "/bin/claude", codexBin: "", policy: { projectionMargin: 3, greedySessionFloor: 40, switchModels: ["fable", "opus"], usagePollTtlMs: 60_000, maxWaitMs: 3_600_000 } });
+  test("a fully overridden file loads verbatim", () => {
+    writeFileSync(paths.configJson, JSON.stringify({ thresholds: { session: 90, weekly: 93 }, claudeBin: "/bin/claude", codexBin: "", policy: { projectionMargin: 3, greedySessionFloor: 40, switchModels: ["fable", "opus"], usagePollTtlMs: 60_000, maxWaitMs: 3_600_000 } }));
     const c = loadConfig();
     expect(c.thresholds).toEqual({ session: 90, weekly: 93 });
     expect(c.policy.projectionMargin).toBe(3);
@@ -42,7 +43,7 @@ describe("accounts round-trip", () => {
     const idx = loadAccounts();
     expect(idx.accounts.length).toBe(1);
     expect(idx.activeAccountUuid).toBe(acct().accountUuid);
-    expect((idx.accounts[0]!.oauthAccount as any).extra).toBe("kept");
+    expect(z.looseObject({ extra: z.string() }).parse(idx.accounts[0]!.oauthAccount).extra).toBe("kept");
   });
 });
 


### PR DESCRIPTION
## What

The iteration-4 unhinted closing adversarial review (111-agent Workflow: 8 dimension finders, dedupe, 2-of-3 refuter verification per finding, completeness critic) confirmed 26 findings out of 34 and 3 substantive gaps. This PR closes 25 findings + all 3 gaps. The 26th (codex exhausted-sibling reconcile, codexdecide.ts) is owner-approved option (b) and ships as its own follow-up PR.

## High severity

- **serve.ts crash-orphan race**: `handleTurn` now reaps a surviving `activeTurn` marker before running. Inside the per-thread serialized chain a marker can only be a previous generation's killed turn, and an inbound message (e.g. Slack redelivering the killed turn's unacked mention) could win the chain ahead of startup recovery, overwrite the marker, strand the orphan's pid forever, and put **two claude processes on one cwd+session**. Pinned with a real detached-sleeper orphan test.

## Medium severity

- **decide.ts label-drift stamp**: the locked-section usage write resolves the account by the LIVE org the guard just verified, never the drifted `activeAccountUuid` label (manual /login is the repo-acknowledged surviving drift source). Pinned in decide.test.ts.
- **codexstophook.ts unsupervised strand**: no supervisor id = no decision at all; a swap with nobody to respawn strands an unsupervised codex session (IDE extension, absolute-path launch) on a token its guarded reload refuses to refresh.
- **supervisor.ts slug**: `-c` continuation now uses claude's real project-dir mapping - EVERY non-alphanumeric char to `-` (binary-verified 2.1.215; the old `[/.]`-only mapping silently opened a brand-new session for cwds containing `_` etc.). External-contract regex exception.
- **switch.ts greedy fallback**: mirrors decide.ts's greedy loop (re-check `currentWins` after each dead grant) instead of `chooseAndSwap`, whose fallback would trade a healthy seat for a pace-worse account and bounce back on the next check.
- **config.ts `set` merged validation**: a per-field-valid value (e.g. `projectionMargin 96` under default thresholds) could brick every later `loadConfig`. `cmdSet` now validates the merged whole through the new shared `mergeConfigFile` seam. Pinned.
- **init/codexinit merged-config bake**: bin pins are sparse-file writes (`pinBinOverride`); `saveConfig` is deleted outright - it baked every default plus ambient `TOKENMAXXING_*_BIN` env overrides into config.json, freezing future default changes and misreporting `xx config` sources.
- **oauth omit-fallback test**: the test named for the omit case never omitted; an `OMIT` sentinel in the mock now exercises the real fallback (losing it persists `refreshToken: undefined` over a parked backup, destroying the grant).
- **README/DESIGN drift**: `projectionMargin` is a fixed margin (no EMA exists anywhere); the periodic check job is documented in DESIGN §2 and the "no background daemon" claim is scoped to the switching path; the statusline is documented as the native replacement it has been since 2026-07-11; settings-entry counts corrected to 4; the Stop-hook step describes greedy engagement, not the pre-0.10.0 hard-bar-only behavior.

## Low severity

sample.ts fail-closed live-owner guard before any parked refresh/probe (crash-drift window); codexsample/codexdecide never refresh a PRESENT account's token (concurrent refresh POSTs of the same rotating token reuse-punish the loser into a dead grant family; the live branch fetches on the unrotated still-valid token instead); tokens-less auth.json (`--with-api-key`; `Option<TokenData>` + `skip_serializing_if`, first-hand source-verified at rust-v0.144.5) reads as "no poolable login" instead of crashing the shim; unlinked-channel check precedes the drain notice (log-only-silent contract, pinned); `parkPlan`'s dead `now` param removed; `analyzeArgs` skips value-taking/variadic/optional-value root flag values (--help-verified 2.1.215, pinned) and passes `--fork-session` resumes through unmanaged (pinned); init's fresh import runs under the tokenmaxxing flock like every sibling index writer; `xx switch <sel> --codex` accepts the flag anywhere; keychain tests get unconditional `afterAll` cleanup; the `as any` / `as` casts are replaced with zod narrowing.

## Critic gaps

1. **CI artifact verification**: the test job packs the tarball, asserts the committed exec bit on the bun-shebang bin and the serve-plugin `.claude-plugin/plugin.json` dotdir (both verified green locally today - no live break), then `bun add -g`'s the tarball and runs it: exactly the 0.2.0 failure class `bun test` cannot see.
2. **Uninstall hygiene**: deactivation is verified, not assumed - launchctl by its locally-verified 0/113 exit contract, systemctl by the documented printed-state contract with the dead-bus failure mode container-verified (ubuntu:24.04, no user bus: empty stdout, stderr error) so "cannot ask" never reads as "not loaded"; uninstall also removes the marker-tagged rc PATH line (the supervisor-recursion incident vector) and prints exactly what it keeps (parked credentials, slack.json tokens).
3. **Residue/unbounded state**: `xx rm` sweeps the removed account's sample-probe residue (isolated keychain item + dir - hard-deleted under the credential-dir exception, since the dir can hold plaintext creds on Linux); `tokenmaxxing.log` gets a 5MB rotate-to-.old cap; slack-threads' no-age-out retention is documented in-file as an intentional tradeoff (records are tiny resumable conversations; a time reaper would silently kill threads).

## Verification

- `bun run typecheck`: clean
- `bun test`: **383 pass / 1 skip / 0 fail** (8 new pinning tests)
- `bun test/e2e/swap-concurrency.ts`: **ALL PASS** (decision-path change rule)
- CI pack-verify greps validated against a real local `npm pack`
- Commit is unsigned: 1Password vault locked; `--no-gpg-sign` fallback has standing owner authorization (2026-07-19/20). The squash merge lands GitHub-signed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on credential refresh, flock-guarded swaps, and Slack daemon concurrency—high-impact paths—but behavior is tightened with new regression tests rather than broad new features.
> 
> **Overview**
> Closes a large batch of **closing-review findings** across switching, packaging, config, Slack serve, codex, and uninstall—mostly correctness and safety guards rather than new product surface.
> 
> **Release & hygiene:** CI now **`npm pack`s**, checks the bin exec bit and serve-plugin dotdir in the tarball, then **`bun add -g`** with an absolute path and runs `tokenmaxxing help` (the failure mode unit tests miss). Uninstall **verifies** timer teardown (launchctl/systemd), removes only the **marker-tagged** rc PATH line, and reports what was actually removed vs kept. **`tokenmaxxing.log`** rotates at 5MB; **`xx rm`** sweeps sample-probe credential residue.
> 
> **Switching & identity:** Decision, greedy auto-`switch`, and `chooseAndSwap` now treat the **live login org** as the seat (not a drifted `activeAccountUuid` label); unpooled live creds **no-op** instead of parking against the wrong account. **`xx config set`** and **`init` / `init --codex`** validate the **merged** config; binary pins use sparse **`pinBinOverride`** instead of writing a full merged `config.json`. Parked/live sampling and codex refresh skip **present supervised** sessions to avoid refresh-token reuse punishment.
> 
> **Supervisor, codex, Slack:** Supervisor arg parsing skips value-taking root flags and leaves **`--fork-session` resumes** unmanaged; **`-c`** project slug matches Claude’s non-alnum→`-` rule. Codex Stop hook **skips swaps** without a supervisor; API-key **`auth.json`** (no `tokens`) reads as non-poolable. Serve **reaps orphan `activeTurn`** before a new message, checks **unlinked channels** before drain notices, and documents slack-thread retention.
> 
> **Docs:** README/DESIGN updated for native statusline takeover, four settings hooks, periodic **`tokenmaxxing check`**, and **`projectionMargin`** as a fixed bar margin (not EMA).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80fe11310bddbf12b4abdee9495fb1316eb91f8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes 25 findings from the iteration-4 closing review and fixes 3 critical gaps to stabilize switching, Slack daemon behavior, config/init/uninstall, and release packaging. Adds a live-org guard: when the current org is known but not pooled, decisions stand down instead of seating a stale label.

- **Bug Fixes**
  - Slack serve: reaps crash-orphaned turns before handling new messages; unlinked-channel check runs before drain notices.
  - Switching/decision: usage stamps and the seat resolve from the live org across all paths (greedy, depleted, `chooseAndSwap`, and bare `xx switch`); one `claude.json` snapshot feeds both the drift check and the seat; KNOWN-but-unpooled live org stands down cleanly; `switch` mirrors the greedy loop; `chooseAndSwap` uses the caller-resolved seat; `xx switch <sel> --codex` accepts the flag anywhere.
  - Codex: skip swaps when unsupervised; API-key `auth.json` (no `tokens`) reads as non-poolable; never refresh PRESENT accounts’ tokens; live sampling refreshes only when safe.
  - Supervisor/CLI: `-c` slug matches Claude’s non-alnum→`-` mapping; arg analysis ignores value-taking/variadic/optional root flags and passes `--fork-session` resumes through unmanaged.
  - Config/init/rm: `xx config set` validates the merged whole; bin pins use sparse writes via `pinBinOverride`; `init`/`codex init` fail fast on a merged-invalid config; `init`/`rm` index writes run under the tool flock; `rm` sweeps sample-probe residue (isolated keychain item + dir).
  - Install/uninstall/CI: uninstall verifies timer deactivation (launchctl/systemd), removes only the marker-tagged PATH line, and headlines only what was verifiably removed; CI packs the tarball, asserts bin exec bit and serve-plugin presence, installs the tarball by absolute path, then runs it.
  - Logging/state/docs: `tokenmaxxing.log` rotates at 5MB to `.old`; minor ENOENT/EEXIST guards; README/DESIGN updates (native statusline, periodic check job, greedy notes, fixed `projectionMargin`, settings count).

<sup>Written for commit 80fe11310bddbf12b4abdee9495fb1316eb91f8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anaclumos/tokenmaxxing/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

