### PR TITLE
docs: record the .memory public-knowledge rule (1.0.2)

### DIFF
--- a/.memory/MEMORY.md
+++ b/.memory/MEMORY.md
@@ -1,5 +1,8 @@
 # Memory index
 
+RULES: this folder is git-tracked in a PUBLIC repo. Treat every note as a public Wikipedia page: public knowledge only. Never device info (hostnames, ssh aliases, hardware identity, machine usernames), never Slack info (conversation, user, workspace, or channel details, any Slack IDs), never environment info (.env keys, file information about the owner's environment). See [[memory-is-public]].
+
+- [.memory is public](memory-is-public.md) - user rule 2026-07-20: git-tracked in the public repo, so public knowledge only; no device, Slack, or environment info; Wikipedia-page standard for every note
 - [Auto-compact 50% override](autocompact-pct-override.md) - CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 in ~/.claude/settings.json env (2026-07-19); undocumented, binary-verified 2.1.215, re-verify after claude updates
 - [Review window is mandatory full-length](review-window-is-mandatory-full-length.md) - hook correction 2026-07-19: the 10-min PR window runs its FULL length from the last push; "all reviewer checks pass" never shortens it (cubic posts findings after its check greens); early merge = compensating late-review watch + fix-forward
 - [Silence is not approval for design forks](silence-is-not-approval-for-design-forks.md) - hook correction 2026-07-19: a surfaced fork holds until the owner picks; an unanswered ping never authorizes the stated lean; only in-plan actions (retry same mechanism, cancel dead tasks, watch) continue meanwhile

--- a/.memory/memory-is-public.md
+++ b/.memory/memory-is-public.md
@@ -1,0 +1,18 @@
+---
+name: memory-is-public
+description: User rule 2026-07-20 - .memory is git-tracked in the public repo, so notes carry only public knowledge; no device, Slack, or environment info; Wikipedia-page standard
+metadata:
+  type: feedback
+---
+
+`.memory` is committed to a PUBLIC GitHub repo, so everything written here is readable by the whole internet. The user's rule (2026-07-20): treat this folder as a public Wikipedia page and record only public knowledge.
+
+Never add:
+
+- Device info: hostnames, ssh aliases, hardware identity, machine usernames, local paths that identify a specific machine.
+- Slack info: conversation details, user details, workspace details, channel details, any Slack IDs.
+- Environment info: .env keys, file information about the owner's environment, credential locations.
+
+**Why:** the traditional agent-memory convention keeps `.memory` gitignored and private, but this repo tracks it, so a habit of recording device or workspace specifics would publish them. The rule keeps the folder safe to commit.
+
+**How to apply:** before writing or editing any note here, strip it down to the generic lesson. A gotcha about an OS, CLI, or library is public and fine; the name or address of the machine it was learned on is not. A note that is only useful with a private detail does not belong here at all. Link: [[tokenmaxxing-project]].

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,12 @@ On every edit, delete:
 - Never dump a full HTTP error or response that may carry a token; allowlist the fields you need. Scrub request headers from thrown ky errors before they reach logs (a ky error carries its request, Authorization header included), and treat any token visible in an error payload as exposed.
 - Live linked Slack channels are production surfaces (rule harvested from Slaude's incident the day serve went live): never post test or probe messages into a real workspace without in-the-moment approval - a goal statement is not send-by-send approval. Owner-instructed decision pings (the ship-flow Slack tag) remain the standing exception.
 
+## Memory
+
+- `.memory` is git-tracked and this repo is PUBLIC (user rule 2026-07-20): treat the folder as a public Wikipedia page. Only public knowledge goes in.
+- Never add: device info (hostnames, ssh aliases, hardware identity, machine usernames, local paths that identify a specific machine), Slack info (conversation details, user details, workspace details, channel details, any Slack IDs), or environment info (.env keys, file information about the owner's environment, credential locations).
+- Generic technical knowledge stays: CLI internals, protocol details, OS gotchas, verified library behavior. The test is whether the note would be fine on a public Wikipedia page; when a lesson is only useful with an identifying detail, keep the generic lesson and leave the detail out.
+
 ## Project
 
 tokenmaxxing (greenfield 2026-07-08) is the owner's CLI for managing usage quota across their own agent-CLI accounts: pool the owner's Claude Code (and eventually Codex) logins, swap to a fresher one when the active account nears its 5-hour or weekly limit, and keep sessions continuable across swaps. Every design decision serves that goal. Full design lives in `DESIGN.md` (auth/quota internals in its §2).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenmaxxing",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Automatic Claude Code account switching: pool multiple accounts and hot-swap when quota fills, resuming your session on the fresh account.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## What

`.memory` is git-tracked and this repo is public, so the owner ruled (2026-07-20) that the folder may hold only public knowledge, held to the standard of a public Wikipedia page: never device info (hostnames, ssh aliases, hardware identity, machine usernames), Slack info (conversation, user, workspace, or channel details, any Slack IDs), or environment info (.env keys, file information about the owner's environment).

- AGENTS.md: new Memory section with the banned categories
- .memory/MEMORY.md: RULES header plus an index pointer
- .memory/memory-is-public.md: the full note (why + how to apply)
- package.json: 1.0.2 (ship policy includes the release)

## Verification

- bun run typecheck: clean
- bun test: 407 pass, 4 skip, 0 fail
- em-dash/interpunct grep over changed files: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version bump only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Documents a **2026-07-20 owner rule**: because `.memory` is committed in a **public** repo, notes must be **public knowledge only** (Wikipedia-page bar), with explicit bans on device, Slack, and environment-identifying details.
> 
> **AGENTS.md** gains a **Memory** section so agents see the rule beside other safeguards. **`.memory/MEMORY.md`** adds a **RULES** header at the top and an index entry. **`.memory/memory-is-public.md`** is the canonical note (rationale + how to apply). **`package.json`** bumps **1.0.1 → 1.0.2** per ship policy (release bundled with the doc change).
> 
> No application or CLI behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93586bd27f7673c7aab50c748c45bc102503c120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the rule that `.memory` is public-only, held to a Wikipedia-page standard.
Add a Memory section in `AGENTS.md`, a RULES header and index pointer in `.memory/MEMORY.md`, the canonical note `.memory/memory-is-public.md`, and bump `package.json` to `1.0.2`; no runtime changes.

<sup>Written for commit 93586bd27f7673c7aab50c748c45bc102503c120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anaclumos/tokenmaxxing/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

