### PR TITLE
chore: release 1.8.0

### DIFF
--- a/agent-plugin/plugin.json
+++ b/agent-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "tokenmaxxing",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Pool Claude Code and Codex logins, switch on pace pressure, and expose safe ops tools to agent clients.",
   "author": {
     "name": "anaclumos",
@@ -10,5 +10,11 @@
   "homepage": "https://github.com/anaclumos/tokenmaxxing",
   "repository": "https://github.com/anaclumos/tokenmaxxing",
   "license": "MIT",
-  "keywords": ["claude", "codex", "quota", "account-switching", "mcp"]
+  "keywords": [
+    "claude",
+    "codex",
+    "quota",
+    "account-switching",
+    "mcp"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenmaxxing",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Automatic Claude Code account switching: pool multiple accounts and hot-swap when quota fills, resuming your session on the fresh account.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Durable tmux relay companion (`tokenmaxxing relay`) plus host agents/skill for Claude and Codex sessions
- Soft-skip shell rc PATH edits on Home Manager / nix-store paths (fixes `xx init` EACCES)
- Home Manager module adds the supervisor bin to `home.sessionPath`

## Test plan
- [x] Main CI green on unreleased merges (`2616a9a` relay + HM zshrc soft-skip)
- [ ] PR CI green (test + nix)
- [ ] After merge, `gh release create v1.8.0` and confirm `npm view tokenmaxxing version` is `1.8.0`