### PR TITLE
docs: ban dynamic workflows, spawn subagents by hand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ No external installed user base, so this is pre-production code: delete old-stat
 - This machine runs live supervisors, hooks, the periodic check, and the owner's real claude sessions. Stop processes by PID, and never kill a running session or supervisor to free a resource without asking.
 - The owner's hosts are managed environments: never run `init`, `add`, `auth`, `uninstall`, or anything that writes settings.json, launchd/systemd units, shell rc, or the global package on a live host (owner, 2026-08-30). Ship code; activation is the owner's step.
 - This working tree is a shared checkout (the owner and other agents work in it live). Stage commits by explicit path, never `git add -A`/`-u` (hook correction, 2026-08-30).
+- No dynamic workflows on this repo: never orchestrate through the Workflow tool or any scripted fan-out. Spawn every subagent by hand, one deliberate Agent call per subagent with a prompt crafted for that task (owner, 2026-09-10).
 - Never print credential material: keychain blobs, `.credentials.json`, `auth.json`, OAuth access or refresh tokens. Report account labels and status only. A ky error carries its request, Authorization header included.
 - Ask before any run that meters real quota or opens a session window (`status --ping`, live-pool runs). Free `/usage` reads are fine.
 - This repo is PUBLIC. The no-Slack-info and no-device-info rule covers PR bodies, commit messages, review replies, release notes, and docs, not just `.memory`.


### PR DESCRIPTION
Adds an agent rule to AGENTS.md: no Workflow-tool or scripted fan-out orchestration on this repo. Every subagent is one deliberate Agent call with a prompt crafted for its task. Docs-only, no packed file changes, so no bump or release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a rule to `AGENTS.md` banning dynamic workflows and scripted fan-out orchestration on this repo. Subagents must now be spawned one deliberate `Agent` call at a time with a prompt crafted for each task. Docs-only change, so no version bump or release.

<sup>Written for commit b2c735adec0217435f5e90cdc6de400987a5c221. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anaclumos/tokenmaxxing/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

