### PR TITLE
chore: platform idioms, one PR (1.38.0)

### DIFF
--- a/.cursor/rules/MEMORY.md
+++ b/.cursor/rules/MEMORY.md
@@ -1,3 +1,4 @@
 # Memory index
 
 - [Switch verification and profiling](switch-verification.md) records the review corrections from 2026-09-10.
+- [Platform idioms](platform-idioms.md) records the Bun and zod behaviors that decide which hand-rolled reads stay.

--- a/.cursor/rules/platform-idioms.md
+++ b/.cursor/rules/platform-idioms.md
@@ -1,0 +1,12 @@
+# Platform idioms
+
+Verified against Bun 1.4.2, bun-types 1.3.14, and zod 4.4.3. Both move monthly; re-verify a line before relying on it.
+
+- `Bun.stdin.text()` strips a leading UTF-8 BOM. The `Bun.stdin.stream()` plus `Buffer.concat` read keeps it, so `JSON.parse` fails on a BOM-prefixed payload under the stream read and succeeds under `text()`. The hook and statusline stdin readers keep the stream read so that a BOM-prefixed payload stays "no payload".
+- `z.json()` output does not `.pipe()` into an object schema under TypeScript: `JSONType` is not assignable to an object input with optional keys. Parse text with `JsonTextSchema.safeParse(text).data` and hand the value to the target schema. A failed parse yields `undefined`, which every object schema rejects the same way as a `null` or `{}` sentinel.
+- A zod codec whose `decode` throws propagates the exception out of `safeParse`. Push an issue through `ctx.issues` and return `z.NEVER` instead.
+- `z.unknown()` is a required key in a zod 4 object schema. A key that may be absent needs `.optional()`.
+- `node:util` `parseArgs` cannot reproduce the `main.ts` flag handling byte for byte: strict mode rejects subcommand-owned flags such as `auth --all`, and non-strict mode consumes `--` and stops stripping the three global flags after it. The three `includes` calls and the one `filter` stay.
+- `Bun.TOML.parse` reads `cli_auth_credentials_store` the way codex does: a top-level key only, and a malformed file throws. A line scan also matches the key inside a `[table]` and tolerates a malformed file.
+- `writeFileSync(fd, data)` loops over partial writes and encodes a string as UTF-8, so `writeFileAtomic` needs no write loop and no `TextEncoder`.
+- `Bun.spawn` `timeout` with `killSignal` replaces a manual `setTimeout` kill. The timer dies with the child, and a throw before the child exits no longer leaves the child running.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenmaxxing",
-  "version": "1.35.0",
+  "version": "1.38.0",
   "description": "Automatic Claude Code account switching: pool multiple accounts and hot-swap when quota fills, resuming your session on the fresh account.",
   "type": "module",
   "license": "MIT",

--- a/src/entries/codexstophook.ts
+++ b/src/entries/codexstophook.ts
@@ -11,7 +11,7 @@ import { isExhausted } from "../lib/picker.ts";
 import { livingCodexPresences } from "../lib/codexpresence.ts";
 import { loadAccounts } from "../lib/state.ts";
 import { CODEX_SUPERVISOR_ID_ENV } from "./codexsupervisor.ts";
-import { CodexReconcileMarkerSchema, CodexRespawnMarkerSchema, CodexStopStdinSchema } from "../lib/types.ts";
+import { CodexReconcileMarkerSchema, CodexRespawnMarkerSchema, CodexStopStdinSchema, JsonTextSchema } from "../lib/types.ts";
 import { log } from "../lib/log.ts";
 
 const SupervisorIdSchema = z.string().min(1).optional().catch(undefined);
@@ -85,13 +85,7 @@ async function readStdin(): Promise<string> {
 }
 
 export async function handleCodexStop(input: { rawStdin: string }): Promise<void> {
-  const parsed = CodexStopStdinSchema.safeParse((() => {
-    try {
-      return JSON.parse(input.rawStdin);
-    } catch {
-      return {};
-    }
-  })());
+  const parsed = CodexStopStdinSchema.safeParse(JsonTextSchema.safeParse(input.rawStdin).data);
   const sessionId = parsed.success ? (parsed.data.session_id ?? null) : null;
 
   try {

--- a/src/entries/sessionstart.ts
+++ b/src/entries/sessionstart.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { claude } from "../lib/claude.ts";
 import { evaluateAndMaybeSwap } from "../lib/decide.ts";
 import { log } from "../lib/log.ts";
+import { JsonTextSchema } from "../lib/types.ts";
 
 const SessionStartStdin = z.looseObject({
   source: z.string().optional(),
@@ -18,7 +19,7 @@ export async function runSessionStart(): Promise<number> {
   if (process.env.TOKENMAXXING_PROBE) return 0;
 
   const raw = await readStdin();
-  const parsed = SessionStartStdin.safeParse((() => { try { return JSON.parse(raw); } catch { return {}; } })());
+  const parsed = SessionStartStdin.safeParse(JsonTextSchema.safeParse(raw).data);
   const source = parsed.success ? parsed.data.source : undefined;
 
   try {

--- a/src/entries/statusline.ts
+++ b/src/entries/statusline.ts
@@ -10,6 +10,7 @@ import { makeColors, makeUsagePaint } from "../cli/render.ts";
 import { fmtResetShort } from "../lib/usage.ts";
 import {
   AccountsIndexSchema,
+  JsonTextSchema,
   StatusLineStdinSchema,
   WindowSchema,
   type Account,
@@ -118,12 +119,7 @@ export function renderStatusline(stdinObj: unknown, ctx: RenderCtx): string {
 }
 
 export async function runStatusline(): Promise<number> {
-  const raw = await readStdin();
-  let obj: unknown = null;
-  try {
-    obj = JSON.parse(raw);
-  } catch {
-  }
+  const obj = JsonTextSchema.safeParse(await readStdin()).data ?? null;
   const now = Date.now();
 
   let account: string | null = null;

--- a/src/entries/stopfailurehook.ts
+++ b/src/entries/stopfailurehook.ts
@@ -9,7 +9,7 @@ import { withLock } from "../lib/lock.ts";
 import { claudePool } from "../lib/paths.ts";
 import { POST_SWAP_COOLDOWN_MS, loadConfig, loadLastSwapAt } from "../lib/state.ts";
 import { classifyEnforcedLimit, findEnforcedRow, parseErrorBody, readTranscriptTail } from "../lib/usage.ts";
-import { RespawnMarkerSchema, type EnforcedLimit } from "../lib/types.ts";
+import { JsonTextSchema, RespawnMarkerSchema, type EnforcedLimit } from "../lib/types.ts";
 import { log } from "../lib/log.ts";
 
 const StopFailureStdin = z.looseObject({
@@ -35,7 +35,7 @@ export async function runStopFailureHook(): Promise<number> {
   const account = entry.account;
   const now = Date.now();
   const raw = await readStdin();
-  const parsed = StopFailureStdin.safeParse((() => { try { return JSON.parse(raw); } catch { return {}; } })());
+  const parsed = StopFailureStdin.safeParse(JsonTextSchema.safeParse(raw).data);
   const stdin = parsed.success ? parsed.data : {};
   if (stdin.error !== undefined && stdin.error !== "rate_limit") return 0;
 

--- a/src/entries/stophook.ts
+++ b/src/entries/stophook.ts
@@ -4,7 +4,7 @@ import { paths } from "../lib/paths.ts";
 import { writeFileAtomic } from "../lib/atomic.ts";
 import { claude } from "../lib/claude.ts";
 import { evaluateAndMaybeSwap } from "../lib/decide.ts";
-import { RespawnMarkerSchema } from "../lib/types.ts";
+import { JsonTextSchema, RespawnMarkerSchema } from "../lib/types.ts";
 import { log } from "../lib/log.ts";
 
 const StopStdin = z.looseObject({ session_id: z.uuid().optional().catch(undefined) });
@@ -19,7 +19,7 @@ export async function runStopHook(): Promise<number> {
   if (process.env.TOKENMAXXING_PROBE) return 0;
 
   const raw = await readStdin();
-  const parsed = StopStdin.safeParse((() => { try { return JSON.parse(raw); } catch { return {}; } })());
+  const parsed = StopStdin.safeParse(JsonTextSchema.safeParse(raw).data);
   const stdinSid = parsed.success ? parsed.data.session_id : undefined;
   const pinnedSid = process.env.TOKENMAXXING_SESSION_ID;
 

--- a/src/entries/subagentstatusline.ts
+++ b/src/entries/subagentstatusline.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { makeColors, makeUsagePaint } from "../cli/render.ts";
 import { readStdin } from "./statusline.ts";
-import { SubagentStatusLineStdinSchema } from "../lib/types.ts";
+import { JsonTextSchema, SubagentStatusLineStdinSchema } from "../lib/types.ts";
 
 const RowCtxSchema = z.object({ color: z.boolean(), truecolor: z.boolean() });
 export type RowCtx = z.infer<typeof RowCtxSchema>;
@@ -43,12 +43,7 @@ export function renderSubagentRows(stdinObj: unknown, ctx: RowCtx): string[] {
 }
 
 export async function runSubagentStatusline(): Promise<number> {
-  const raw = await readStdin();
-  let obj: unknown = null;
-  try {
-    obj = JSON.parse(raw);
-  } catch {
-  }
+  const obj = JsonTextSchema.safeParse(await readStdin()).data ?? null;
   const colorterm = z.string().optional().parse(process.env.COLORTERM);
   const rows = renderSubagentRows(obj, {
     color: !process.env.NO_COLOR,

--- a/src/lib/atomic.ts
+++ b/src/lib/atomic.ts
@@ -1,20 +1,14 @@
-import { closeSync, mkdirSync, openSync, renameSync, rmSync, writeSync, fsyncSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, renameSync, rmSync, writeFileSync, fsyncSync } from "node:fs";
 import { dirname } from "node:path";
 
 export function writeFileAtomic(file: string, data: string | Uint8Array, mode = 0o600): void {
   const dir = dirname(file);
   mkdirSync(dir, { recursive: true });
   const tmp = `${file}.tmp.${process.pid}.${Math.floor(Math.random() * 1e9).toString(36)}`;
-  const bytes = data instanceof Uint8Array ? data : new TextEncoder().encode(data);
   const fd = openSync(tmp, "wx", mode);
   try {
     try {
-      let offset = 0;
-      while (offset < bytes.length) {
-        const written = writeSync(fd, bytes, offset);
-        if (written <= 0) throw new Error(`short write on ${tmp}: ${offset}/${bytes.length} bytes (disk full?)`);
-        offset += written;
-      }
+      writeFileSync(fd, data);
       fsyncSync(fd);
     } finally {
       closeSync(fd);

--- a/src/lib/claudelock.ts
+++ b/src/lib/claudelock.ts
@@ -1,9 +1,9 @@
 import { mkdirSync, realpathSync, rmdirSync, statSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { delay } from "es-toolkit";
-import { z } from "zod";
 import { credDir } from "./paths.ts";
 import { log } from "./log.ts";
+import { ErrnoSchema } from "./types.ts";
 
 const STALE_MS = 60_000;
 const HEARTBEAT_MS = 5_000;
@@ -15,8 +15,7 @@ function tryAcquire(lockDir: string): boolean {
     mkdirSync(lockDir);
     return true;
   } catch (e) {
-    const errno = z.object({ code: z.string() }).safeParse(e);
-    if (!errno.success || errno.data.code !== "EEXIST") throw e;
+    if (ErrnoSchema.safeParse(e).data?.code !== "EEXIST") throw e;
   }
   try {
     if (Date.now() - statSync(lockDir).mtimeMs > STALE_MS) {

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -259,16 +259,8 @@ async function importLive(): Promise<Harvest | null> {
 function storePinnedAwayFromFile(): boolean {
   const configToml = `${codexPaths.home}/config.toml`;
   if (!existsSync(configToml)) return false;
-  for (const rawLine of readFileSync(configToml, "utf8").split("\n")) {
-    const line = rawLine.trim();
-    if (!line.startsWith("cli_auth_credentials_store")) continue;
-    const rest = line.slice("cli_auth_credentials_store".length).trimStart();
-    if (!rest.startsWith("=")) continue;
-    const beforeComment = rest.slice(1).split("#", 1)[0]!;
-    const value = beforeComment.replaceAll('"', "").replaceAll("'", "").trim();
-    return value !== "file";
-  }
-  return false;
+  const config = Bun.TOML.parse(readFileSync(configToml, "utf8"));
+  return "cli_auth_credentials_store" in config && config.cli_auth_credentials_store !== "file";
 }
 
 function preflight(): void {

--- a/src/lib/codexauth.ts
+++ b/src/lib/codexauth.ts
@@ -3,18 +3,14 @@ import { join } from "node:path";
 import { z } from "zod";
 import { writeFileAtomic } from "./atomic.ts";
 import { codexPaths } from "./paths.ts";
-import { CodexAuthJsonSchema, type CodexAuthJson } from "./types.ts";
-
-function isEnoent(e: unknown): boolean {
-  return e instanceof Error && "code" in e && e.code === "ENOENT";
-}
+import { CodexAuthJsonSchema, ErrnoSchema, type CodexAuthJson } from "./types.ts";
 
 export function readCodexAuthAt(input: { path: string }): CodexAuthJson | null {
   let raw: string;
   try {
     raw = readFileSync(input.path, "utf8");
   } catch (e) {
-    if (isEnoent(e)) return null;
+    if (ErrnoSchema.safeParse(e).data?.code === "ENOENT") return null;
     throw e;
   }
   const parsed = JSON.parse(raw);
@@ -46,7 +42,7 @@ export function readParkedCodexAuth(input: { credFile: string }): CodexAuthJson 
   try {
     raw = readFileSync(parkedPath(input), "utf8");
   } catch (e) {
-    if (isEnoent(e)) return null;
+    if (ErrnoSchema.safeParse(e).data?.code === "ENOENT") return null;
     throw e;
   }
   return CodexAuthJsonSchema.parse(JSON.parse(raw));

--- a/src/lib/codexoauth.ts
+++ b/src/lib/codexoauth.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 import { http, oauthErrorCode, safeErrorDetail } from "./http.ts";
-import { CodexAuthJsonSchema, type CodexAuthJson } from "./types.ts";
+import { env } from "./paths.ts";
+import { CodexAuthJsonSchema, JsonTextSchema, type CodexAuthJson } from "./types.ts";
 
-const EnvOverrideSchema = z.string().min(1).optional().catch(undefined);
-const TOKEN_URL = EnvOverrideSchema.parse(process.env.TOKENMAXXING_CODEX_TOKEN_URL) ?? "https://auth.openai.com/oauth/token";
-const CLIENT_ID = EnvOverrideSchema.parse(process.env.TOKENMAXXING_CODEX_CLIENT_ID) ?? "app_EMoamEEZ73f0CkXaXp7hrann";
+const TOKEN_URL = env("TOKENMAXXING_CODEX_TOKEN_URL", "https://auth.openai.com/oauth/token");
+const CLIENT_ID = env("TOKENMAXXING_CODEX_CLIENT_ID", "app_EMoamEEZ73f0CkXaXp7hrann");
 
 export class CodexInvalidGrantError extends Error {
   constructor(detail: string) {
@@ -60,13 +60,7 @@ export async function refreshCodexAuth(input: { auth: CodexAuthJson; now?: numbe
     throw new CodexRefreshFailedError(`HTTP ${res.status}: ${detail}`);
   }
 
-  const parsed = CodexRefreshResponseSchema.safeParse((() => {
-    try {
-      return JSON.parse(text);
-    } catch {
-      return null;
-    }
-  })());
+  const parsed = CodexRefreshResponseSchema.safeParse(JsonTextSchema.safeParse(text).data);
   if (!parsed.success) {
     throw new CodexRefreshFailedError("endpoint returned an unexpected body shape (withheld: may carry tokens)");
   }

--- a/src/lib/codexpresence.ts
+++ b/src/lib/codexpresence.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { codexPaths } from "./paths.ts";
 import { writeFileAtomic } from "./atomic.ts";
 import { pidExists, pidStartTime } from "./proc.ts";
+import { ErrnoSchema, JsonTextSchema } from "./types.ts";
 
 const PresenceSchema = z.object({
   accountId: z.string(),
@@ -38,17 +39,10 @@ export function livingCodexPresences(): LivingPresence[] {
     try {
       raw = readFileSync(file, "utf8");
     } catch (e) {
-      const errno = z.object({ code: z.string() }).safeParse(e);
-      if (errno.success && errno.data.code === "ENOENT") continue;
+      if (ErrnoSchema.safeParse(e).data?.code === "ENOENT") continue;
       throw e;
     }
-    const parsed = PresenceSchema.safeParse((() => {
-      try {
-        return JSON.parse(raw);
-      } catch {
-        return null;
-      }
-    })());
+    const parsed = PresenceSchema.safeParse(JsonTextSchema.safeParse(raw).data);
     if (!parsed.success) {
       throw new Error(`${file} is not a readable presence record - it may belong to a RUNNING codex session, refusing to treat it as absent; remove the file (or respawn that session) to proceed`);
     }

--- a/src/lib/codexusage.ts
+++ b/src/lib/codexusage.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 import { http, safeErrorDetail } from "./http.ts";
-import { CodexUsageSchema, type CodexAuthJson, type CodexUsage, type Window } from "./types.ts";
+import { env } from "./paths.ts";
+import { CodexUsageSchema, JsonTextSchema, type CodexAuthJson, type CodexUsage, type Window } from "./types.ts";
 import { codexIdentityOf } from "./codexauth.ts";
 import { familyTokens } from "./usage.ts";
 
-const EnvOverrideSchema = z.string().min(1).optional().catch(undefined);
-const USAGE_URL = EnvOverrideSchema.parse(process.env.TOKENMAXXING_CODEX_USAGE_URL) ?? "https://chatgpt.com/backend-api/wham/usage";
+const USAGE_URL = env("TOKENMAXXING_CODEX_USAGE_URL", "https://chatgpt.com/backend-api/wham/usage");
 
 export class CodexUsageReadError extends Error {
   constructor(detail: string) {
@@ -70,13 +70,7 @@ export async function fetchCodexUsage(input: { auth: CodexAuthJson; at: number }
   if (!res.ok) {
     throw new CodexUsageReadError(`HTTP ${res.status}: ${safeErrorDetail({ text })}`);
   }
-  const parsed = WireUsageSchema.safeParse((() => {
-    try {
-      return JSON.parse(text);
-    } catch {
-      return null;
-    }
-  })());
+  const parsed = WireUsageSchema.safeParse(JsonTextSchema.safeParse(text).data);
   if (!parsed.success) {
     throw new CodexUsageReadError("endpoint returned an unexpected body shape (withheld)");
   }

--- a/src/lib/credstore.ts
+++ b/src/lib/credstore.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { writeFileAtomic } from "./atomic.ts";
 import * as kc from "./keychain.ts";
 import { credDir, keychain as kcNames, namespacedCredService, paths } from "./paths.ts";
-import { CredentialBlobSchema } from "./types.ts";
+import { CredentialBlobSchema, ErrnoSchema } from "./types.ts";
 
 const CredTargetSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("keychain"), service: z.string(), account: z.string() }),
@@ -16,16 +16,12 @@ const darwin = process.platform === "darwin";
 
 const BlobRecordSchema = z.record(z.string(), z.unknown());
 
-function isEnoent(e: unknown): boolean {
-  return e instanceof Error && "code" in e && e.code === "ENOENT";
-}
-
 export async function readItem(t: CredTarget): Promise<string | null> {
   if (t.kind === "keychain") return kc.readItem(t);
   try {
     return readFileSync(t.path, "utf8");
   } catch (e) {
-    if (isEnoent(e)) return null;
+    if (ErrnoSchema.safeParse(e).data?.code === "ENOENT") return null;
     throw e;
   }
 }
@@ -42,7 +38,7 @@ export async function deleteItem(t: CredTarget): Promise<boolean> {
     unlinkSync(t.path);
     return true;
   } catch (e) {
-    if (isEnoent(e)) return false;
+    if (ErrnoSchema.safeParse(e).data?.code === "ENOENT") return false;
     throw e;
   }
 }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,5 +1,6 @@
 import ky from "ky";
 import { z } from "zod";
+import { JsonTextSchema } from "./types.ts";
 
 const OAuthErrorBodySchema = z.looseObject({
   error: z.string(),
@@ -20,12 +21,8 @@ const ErrorDetailSchema = z.object({ code: z.string().nullable(), fields: z.arra
 type ErrorDetail = z.infer<typeof ErrorDetailSchema>;
 
 function parseErrorBody(text: string): ErrorDetail | null {
-  let json: unknown;
-  try {
-    json = JSON.parse(text);
-  } catch {
-    return null;
-  }
+  const json = JsonTextSchema.safeParse(text).data;
+  if (json === undefined) return null;
   const oauth = OAuthErrorBodySchema.safeParse(json);
   if (oauth.success) return { code: oauth.data.error, fields: [oauth.data.error, oauth.data.error_description ?? ""] };
   const nested = NestedErrorBodySchema.safeParse(json);

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -7,6 +7,7 @@ import { writeFileAtomic } from "./atomic.ts";
 import { installedBin, installSettings, isOurHookCommand, uninstallSettings } from "./settings.ts";
 import { resolveRealClaude } from "./claudebin.ts";
 import { loadConfig } from "./state.ts";
+import { ErrnoSchema } from "./types.ts";
 
 const InstallOutcomeSchema = z.object({
   claudeWrapper: z.string(),
@@ -47,10 +48,6 @@ export function skipImperativeTimer(): boolean {
 
 function isNixStorePath(path: string): boolean {
   return path === "/nix/store" || path.startsWith("/nix/store/");
-}
-
-function isEacces(e: unknown): boolean {
-  return typeof e === "object" && e != null && "code" in e && e.code === "EACCES";
 }
 
 function cannotWriteRcTarget(target: string): boolean {
@@ -355,7 +352,7 @@ export function ensurePathInRc(rc: string): "added" | "present" | "skipped" {
     try {
       writeFileAtomic(target, `${body}${sep0}${addition}`, statSync(target).mode & 0o777);
     } catch (e) {
-      if (isEacces(e)) return "skipped";
+      if (ErrnoSchema.safeParse(e).data?.code === "EACCES") return "skipped";
       throw e;
     }
     return "added";
@@ -366,7 +363,7 @@ export function ensurePathInRc(rc: string): "added" | "present" | "skipped" {
   try {
     appendFileSync(target, `${sep}export PATH="${dir}:$PATH" ${PATH_LINE_MARK}\n`);
   } catch (e) {
-    if (isEacces(e)) return "skipped";
+    if (ErrnoSchema.safeParse(e).data?.code === "EACCES") return "skipped";
     throw e;
   }
   return "added";
@@ -411,7 +408,7 @@ export function removePathFromRc(rc: string): boolean {
   try {
     writeFileAtomic(target, kept.join("\n"), statSync(target).mode & 0o777);
   } catch (e) {
-    if (isEacces(e)) return false;
+    if (ErrnoSchema.safeParse(e).data?.code === "EACCES") return false;
     throw e;
   }
   return true;

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,11 +1,10 @@
-import { z } from "zod";
 import { http, oauthErrorCode, safeErrorDetail } from "./http.ts";
-import { ProfileResponseSchema, RefreshResponseSchema, TokenIdentitySchema, type OAuthCreds, type TokenIdentity } from "./types.ts";
+import { env } from "./paths.ts";
+import { JsonTextSchema, ProfileResponseSchema, RefreshResponseSchema, TokenIdentitySchema, type OAuthCreds, type TokenIdentity } from "./types.ts";
 
-const EnvOverrideSchema = z.string().min(1).optional().catch(undefined);
-const TOKEN_URL = EnvOverrideSchema.parse(process.env.TOKENMAXXING_OAUTH_TOKEN_URL) ?? "https://platform.claude.com/v1/oauth/token";
-const CLIENT_ID = EnvOverrideSchema.parse(process.env.TOKENMAXXING_OAUTH_CLIENT_ID) ?? "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
-const PROFILE_URL = EnvOverrideSchema.parse(process.env.TOKENMAXXING_OAUTH_PROFILE_URL) ?? "https://api.anthropic.com/api/oauth/profile";
+const TOKEN_URL = env("TOKENMAXXING_OAUTH_TOKEN_URL", "https://platform.claude.com/v1/oauth/token");
+const CLIENT_ID = env("TOKENMAXXING_OAUTH_CLIENT_ID", "9d1c250a-e61b-44d9-88ed-5944d1962f5e");
+const PROFILE_URL = env("TOKENMAXXING_OAUTH_PROFILE_URL", "https://api.anthropic.com/api/oauth/profile");
 
 const DEFAULT_SCOPES = [
   "user:profile",
@@ -76,9 +75,7 @@ export async function refreshCredential(creds: OAuthCreds, now = Date.now(), sig
     throw new Error(`token refresh failed (HTTP ${res.status}): ${detail}`);
   }
 
-  const parsed = RefreshResponseSchema.safeParse((() => {
-    try { return JSON.parse(text); } catch { return null; }
-  })());
+  const parsed = RefreshResponseSchema.safeParse(JsonTextSchema.safeParse(text).data);
   if (!parsed.success) {
     throw new Error(`token endpoint returned an unrecognized body (${text.length} bytes, withheld)`);
   }
@@ -119,9 +116,7 @@ export async function fetchTokenIdentity(accessToken: string, signal?: AbortSign
     throw new IdentityUnavailableError(res.status, `profile response body unreadable: ${e instanceof Error ? e.message : String(e)}`);
   }
   if (!res.ok) throw new IdentityUnavailableError(res.status, safeErrorDetail({ text }));
-  const parsed = ProfileResponseSchema.safeParse((() => {
-    try { return JSON.parse(text); } catch { return null; }
-  })());
+  const parsed = ProfileResponseSchema.safeParse(JsonTextSchema.safeParse(text).data);
   if (!parsed.success) throw new IdentityUnavailableError(res.status, `profile endpoint returned an unrecognized body (${text.length} bytes, withheld)`);
   return TokenIdentitySchema.parse({
     accountUuid: parsed.data.account.uuid,

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -6,7 +6,7 @@ const HOME = homedir();
 
 const EnvOverrideSchema = z.string().min(1).optional().catch(undefined);
 
-function env(name: string, fallback: string): string {
+export function env(name: string, fallback: string): string {
   return EnvOverrideSchema.parse(process.env[name]) ?? fallback;
 }
 

--- a/src/lib/proc.ts
+++ b/src/lib/proc.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { ErrnoSchema } from "./types.ts";
 
 export function pidStartTime(pid: number): string | null {
   const res = Bun.spawnSync(["ps", "-p", String(pid), "-o", "lstart="], { env: { ...process.env, LC_ALL: "C" } });
@@ -12,9 +12,9 @@ export function pidExists(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (e) {
-    const errno = z.object({ code: z.string() }).safeParse(e);
-    if (errno.success && errno.data.code === "ESRCH") return false;
-    if (errno.success && errno.data.code === "EPERM") return true;
+    const code = ErrnoSchema.safeParse(e).data?.code;
+    if (code === "ESRCH") return false;
+    if (code === "EPERM") return true;
     throw e;
   }
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -6,6 +6,7 @@ import { writeFileAtomic } from "./atomic.ts";
 import {
   AccountsIndexSchema,
   ConfigSchema,
+  ErrnoSchema,
   LastSwapSchema,
   UsageStateSchema,
   type Account,
@@ -181,8 +182,7 @@ export function writeUsage(input: UsageState, opts: { stamp?: boolean } = {}): b
     try {
       utimesSync(paths.usageJson, new Date(next.ts), new Date(next.ts));
     } catch (e) {
-      const errno = z.object({ code: z.string() }).safeParse(e);
-      if (!errno.success || errno.data.code !== "ENOENT") throw e;
+      if (ErrnoSchema.safeParse(e).data?.code !== "ENOENT") throw e;
     }
     return false;
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -244,3 +244,17 @@ export const CodexReconcileMarkerSchema = z.object({
   accountId: z.string(),
   ts: z.number(),
 });
+
+export const ErrnoSchema = z.object({ code: z.string() });
+
+export const JsonTextSchema = z.codec(z.string(), z.json(), {
+  decode: (text, ctx) => {
+    try {
+      return JSON.parse(text);
+    } catch {
+      ctx.issues.push({ code: "invalid_format", format: "json", input: text });
+      return z.NEVER;
+    }
+  },
+  encode: (value) => JSON.stringify(value),
+});

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -3,7 +3,7 @@ import { delay } from "es-toolkit";
 import { z } from "zod";
 import { MAX_WRAP_DEPTH, WRAP_DEPTH_ENV, resolveRealClaude } from "./claudebin.ts";
 import { log } from "./log.ts";
-import { RateLimitsStdinSchema, type ModelInfo, type UsageWindow, type UsageWindows, type Window } from "./types.ts";
+import { JsonTextSchema, RateLimitsStdinSchema, type ModelInfo, type UsageWindow, type UsageWindows, type Window } from "./types.ts";
 
 export function normalizeResetsAt(v: unknown): number | null {
   const num = z.number().finite().safeParse(v);
@@ -279,21 +279,16 @@ const SpawnResultSchema = z.object({
 type SpawnResult = z.infer<typeof SpawnResultSchema>;
 
 async function spawnClaudeBounded(cmd: string[], env: Record<string, string>): Promise<SpawnResult | null> {
-  const p = Bun.spawn(cmd, { env, stdout: "pipe", stderr: "pipe" });
-  const killer = setTimeout(() => p.kill("SIGKILL"), PROBE_KILL_MS);
-  try {
-    const reads = Promise.all([new Response(p.stdout).text(), new Response(p.stderr).text()]);
-    const settled = await Promise.race([
-      reads,
-      p.exited.then(() => delay(PIPE_GRACE_MS)).then(() => null),
-    ]);
-    if (settled === null) return null;
-    const [stdout, stderr] = settled;
-    await p.exited;
-    return { exitCode: p.exitCode, stdout, stderr };
-  } finally {
-    clearTimeout(killer);
-  }
+  const p = Bun.spawn(cmd, { env, stdout: "pipe", stderr: "pipe", timeout: PROBE_KILL_MS, killSignal: "SIGKILL" });
+  const reads = Promise.all([new Response(p.stdout).text(), new Response(p.stderr).text()]);
+  const settled = await Promise.race([
+    reads,
+    p.exited.then(() => delay(PIPE_GRACE_MS)).then(() => null),
+  ]);
+  if (settled === null) return null;
+  const [stdout, stderr] = settled;
+  await p.exited;
+  return { exitCode: p.exitCode, stdout, stderr };
 }
 
 async function probeUsageOnce(env: Record<string, string>, now: number): Promise<UsageWindows | null> {
@@ -314,7 +309,7 @@ async function probeUsageOnce(env: Record<string, string>, now: number): Promise
     return null;
   }
 
-  const j = z.object({ result: z.string() }).safeParse((() => { try { return JSON.parse(out); } catch { return null; } })());
+  const j = z.object({ result: z.string() }).safeParse(JsonTextSchema.safeParse(out).data);
   const text = j.success ? j.data.result : out;
   const full = parseUsageText(text, now);
   if (!full) {


### PR DESCRIPTION
Closes #96.

Replaces hand-rolled code by platform and dependency idioms where the issue's target still exists in the 1.35.0 tree. Every replacement keeps stdout, stderr, and exit codes byte-identical on a hermetic pool (measurement below). `package.json` moves to 1.38.0.

## Items

| # | Issue item | Status | Where | Note |
|---|---|---|---|---|
| 1 | `Bun.TOML.parse` for the hand TOML scan | done, moved | `src/lib/codex.ts` `storePinnedAwayFromFile` (was `codexinit.ts`) | Reads `cli_auth_credentials_store` as codex does: top-level key only, and a malformed `config.toml` throws where it is read. The line scan also matched the key inside a `[table]` and tolerated a malformed file. `init --codex` is the only caller. |
| 2 | One `z.codec(z.string(), z.json())` in `types.ts` replacing the `try { JSON.parse } catch` IIFEs before `safeParse` | done | `JsonTextSchema` in `src/lib/types.ts`; 10 IIFE sites and 3 `let json; try {...} catch` sites in `stophook.ts`, `stopfailurehook.ts`, `sessionstart.ts`, `codexstophook.ts`, `statusline.ts`, `subagentstatusline.ts`, `usage.ts`, `oauth.ts` (2), `codexoauth.ts`, `codexusage.ts`, `codexpresence.ts`, `http.ts` | The tree had 13 such sites, not 17. Call form is `Schema.safeParse(JsonTextSchema.safeParse(text).data)`: `z.json()` output does not `.pipe()` into an object schema under TypeScript, and a failed parse yields `undefined`, which every target schema rejects the same way as the former `null` or `{}` sentinel. A codec whose `decode` throws propagates out of `safeParse`, so `decode` pushes an `invalid_format` issue and returns `z.NEVER`. The three `cloud.ts` sites stay: each raises its own error text on a parse failure. |
| 3 | `await Bun.stdin.text()` replacing the five identical `readStdin` functions | kept | `stophook.ts`, `stopfailurehook.ts`, `sessionstart.ts`, `codexstophook.ts`, `statusline.ts` | Measured on Bun 1.4.2: `Bun.stdin.text()` strips a leading UTF-8 BOM, the `Buffer.concat` read keeps it, so a BOM-prefixed payload parses under `text()` and falls back to "no payload" today. Codex consult verdict: keep (below). |
| 4 | `writeFileSync(fd, data)` replacing the write loop and `TextEncoder` in `atomic.ts` | done | `src/lib/atomic.ts` | Verified on Bun 1.4.2: a string and a `Uint8Array` written to an `wx` descriptor land sequentially at mode 600. The `short write` throw goes with the loop; `write(2)` reports a full disk as an error, never as a zero-byte write. |
| 5 | `import pkg from "../../package.json"` replacing the cast and `"0.0.0"` fallback | dropped | none | No `package.json` read and no `0.0.0` fallback exist in `src/`. |
| 6 | One exported `env(name, fallback)` from `paths.ts` replacing the `EnvOverrideSchema` copies | done | `src/lib/paths.ts` exports `env`; copies removed from `oauth.ts`, `codexoauth.ts`, `codexusage.ts` | Three copies remained, not six. The `zod` import in `oauth.ts` went dead and is removed. The two `realClaudeBinFromEnv` and `realCodexBinFromEnv` readers keep the schema inside `paths.ts` because they have no fallback. |
| 7 | One exported errno schema replacing seven `code` checks in three idioms | done | `ErrnoSchema` in `src/lib/types.ts`; sites in `codexauth.ts` (2), `credstore.ts` (2), `install.ts` (3), `proc.ts`, `claudelock.ts`, `state.ts`, `codexpresence.ts` | Every check reads `ErrnoSchema.safeParse(e).data?.code`. The `isEnoent` and `isEacces` helpers and the `zod` imports in `proc.ts` and `claudelock.ts` are deleted. |
| 8 | One `redact` in `log.ts` replacing the copy in `mcp.ts` | dropped | none | `mcp.ts` no longer exists; `log.ts` holds the only `redact`. |
| 9 | `Bun.spawn({ timeout, killSignal, signal })` replacing the manual killer in `usage.ts` | done | `src/lib/usage.ts` `spawnClaudeBounded` | `timeout: PROBE_KILL_MS, killSignal: "SIGKILL"` replaces the `setTimeout` kill and its `try/finally`. `signal` is not used: the abort plumbing was deleted in #83 and no caller passes one. `claudebin.ts` already spawns with the same options. Verified on Bun 1.4.2: the child dies with `SIGKILL` at the deadline and the pipe reads still resolve. |
| 10 | `isEqual` and `structuredClone` in `config.ts` | dropped | none | `config.ts` prints only; `state.ts` already uses `isEqual` and no JSON round-trip clone exists. |
| 11 | `mapValues` replacing the two `Object.fromEntries(Object.entries(...).map(...))` in `status.ts` | dropped | none | `status.ts` has no `Object.fromEntries`. The one remaining `Object.fromEntries` in `statusline.ts` keys an array by name, which is not the `mapValues` shape and not an item the issue names. |
| 12 | `node:util` `parseArgs` in `main.ts` replacing `statusFlags` and the five `--codex` filters | dropped | `src/main.ts` | `statusFlags` and the five filters are gone since 1.34.0; four lines remain (three `includes`, one `filter`). Codex consult verdict: drop (below). |

## Codex consults

Two questions were open. Each ran as one `codex exec` consult (`gpt-6-astra`, high reasoning, read-only) and the verdict is implemented as given.

- Item 12, `parseArgs`: **drop**. Strict parsing rejects the subcommand's flag in `auth --all`. Non-strict parsing consumes `--`, so `switch -- foo` changes selector, and it stops recognizing flags after `--` where today's code strips the three exact strings everywhere. Byte-identical behavior needs raw-argument reconstruction, which exceeds the four lines it replaces.
- Item 3, `Bun.stdin.text()`: **keep**. A BOM-prefixed stdin changes from "no payload" to a parsed payload, which can change hook behavior and statusline output. The acceptance rule requires identical observable behavior; the producers' current BOM-free `JSON.stringify` output does not authorize an exception.

## Net line count

`git diff --stat` against `a02afaf` (1.35.0): 25 files changed, 97 insertions, 141 deletions (net minus 44). Packed files only (`src` and `package.json`): 23 files, 84 insertions, 141 deletions (net minus 57).

## Hermetic verification

`bun run typecheck` is clean before and after.

Fixture: a throwaway `HOME`, `TOKENMAXXING_HOME`, `TOKENMAXXING_CLAUDE_JSON`, and `TOKENMAXXING_CODEX_HOME`; `CLAUDE_CONFIG_DIR` unset (`env -i`); `TOKENMAXXING_CLAUDE_BIN=/usr/bin/true`; `TOKENMAXXING_CODEX_BIN=/usr/bin/true`; `NO_COLOR=1`; a synthetic version 2 pool for both providers (three claude accounts, one live in `.credentials.json` and two parked under `creds/`, one unmeasured; two codex accounts, one live in `auth.json` and one parked under `codex-creds/`; a `usage.json` tee for the live claude account; invented ids and labels). The OAuth profile, token, and codex usage URLs point at a local stub through the `TOKENMAXXING_*_URL` overrides, so no request leaves the host: the profile endpoint answers each fixture token with its owner and the token endpoints answer HTTP 400 `invalid_request`. The stub log shows 95 profile reads and 35 token posts across the runs, which exercises the new codec on HTTP bodies (`fetchTokenIdentity`, `parseErrorBody`) and the `env()` overrides.

Each command runs on a fresh copy of the fixture, once on a `git archive` of `origin/main` and once on this branch, capturing stdout, stderr, the exit code, and the state files left behind. A third run on `origin/main` serves as the control for wall-clock drift.

Command matrix: `status --json`, `status --cached --json`, `config --json`, `check --json`, `switch --json`, `status`, `status --cached`, `doctor`, `help`, `rm`, `rename`, `switch nobody`, `bogus --json`, plus `config`, `check`, `switch`, `switch nobody --json`, `rm --json`, `status --codex`, `switch --codex --json`.

Observed:

- Exit-code vector, identical on all three runs, in alphabetical order of the captured `.code` files: `0 0 0 0 1 0 2 2 2 0 0 0 2 0 0 1 0 1 1 2`.
- main vs branch, 200 captured files: 194 byte-identical, 6 differ only in wall-clock epoch fields (`now` and `usageAt` in `status --json`, `now` in `status --cached --json`, `lastProbeAt`, `lastUsageAt`, and `sampledAt` in the `accounts.json` left by `status`, `status --json`, `check`, and `check --json`), 0 differ otherwise. The comparison masks those keys structurally with `jq` and compares every other file with `cmp`.
- main vs main (control): the same 194, 6, and 0, so the six clock-only files drift on an unchanged tree.
- Every `.err` file and every `.code` file is byte-identical between main and branch.
- `switch --json` exits 0 with `switched: false`, `reason: "current-wins"`; `check --json` exits 0 with `swapped: false`, `reason: "under-threshold-or-stale"`; `bogus --json` and `rm --json` exit 2 with the `has no --json form` error document; `switch nobody` exits 1 with `no account matches "nobody"`; `rm` and `rename` exit 2 with their usage lines; `doctor` exits 1 on the throwaway home with every install check failing, as documented.

## Review round

pullfrog: `z.json()` as the codec output revalidated the parsed tree and rejected values `JSON.parse` accepts, so a `1e400` literal (parsed to `Infinity`) made a classifiable OAuth error body unclassified. fb9cc72 makes the output schema `z.unknown()`. Measured with `oauthErrorCode({ text: '{"error":"invalid_grant","ignored":1e400}' })`: `main` returns `invalid_grant`, c408d08 returned `null`, fb9cc72 returns `invalid_grant`; `{` still fails the codec. The rule file states the reason and the actual fallback (a failed parse yields `undefined`, which no target schema accepts, while the all-optional hook and statusline schemas accept an empty object as they accepted the former `{}` sentinel).

## Docs

No documented behavior or file name changes. The lesson file is `.cursor/rules/platform-idioms.md`, indexed from `.cursor/rules/MEMORY.md`.

## Not touched

`src/lib/update.ts` and `src/cli/check.ts` (issue #120 in flight).
